### PR TITLE
Solve the self closing tag issue

### DIFF
--- a/src/main/java/com/osscameroon/jsgenerator/JSGenerator.java
+++ b/src/main/java/com/osscameroon/jsgenerator/JSGenerator.java
@@ -1,5 +1,7 @@
 package com.osscameroon.jsgenerator;
 
+
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -122,60 +124,52 @@ public class JSGenerator {
 
 		System.out.println(convertService.convert(sampleHtml.toString()));
 
-		// Self closing tags
+		
+		logger.log(Level.INFO, " **** Self closing tags without slash   **** ");
 
-		/*
-		 * When input doesn't end with a slash /> at the end of the tag , it doesn't
-		 * work. img looks like a child of input but it's false.
-		 */
+		String selfClosingTagInputWithoutSlashHtml = "<input type=\"text\">\r\n" + "<img src=\"#URL\" alt=\"image\">";
+	
+		
+		logger.log(Level.INFO, "\n\n" + selfClosingTagInputWithoutSlashHtml + "\n");
 
-		/* Jsoup consider self closing tag as the one with a slash /> at the end */
+		logger.log(Level.INFO, " **** generated js  **** ");
+		
 
-		/*
-		 * The program should throw an exception if a non self closing tag like div is
-		 * considered as self closing tag ?
-		 */
+		System.out.println(convertService.convert(selfClosingTagInputWithoutSlashHtml));
+		
+		logger.log(Level.INFO, " **** ***********************  **** ");
 
-		logger.log(Level.INFO, " **** Self closing tags Not working  **** ");
+		String selfClosingTagInputWithoutSlashHtml2 = "<input type=\"text\">\r\n" + "<img src=\"#URL\" alt=\"image\"/>";
 
-		String selfClosingTagsNotWorking = "<input type=\"text\">\r\n" + "<img src=\"#URL\" alt=\"image\">";
+		logger.log(Level.INFO, "\n\n" + selfClosingTagInputWithoutSlashHtml2 + "\n");
 
-		logger.log(Level.INFO, "\n\n" + selfClosingTagsNotWorking + "\n");
+		logger.log(Level.INFO, " **** generated js  **** ");
 
-		logger.log(Level.INFO, " **** generated js:  **** ");
+		System.out.println(convertService.convert(selfClosingTagInputWithoutSlashHtml2).replace("\n", ""));
+		
+		
+		logger.log(Level.INFO, " **** Self closing tags with slash  **** ");
 
-		System.out.println(convertService.convert(selfClosingTagsNotWorking));
+		String selfClosingTagInputWithSlashHtml = "<input type=\"text\"/>\r\n" + "<img src=\"#URL\" alt=\"image\"/>";
+		
+		
+		logger.log(Level.INFO, "\n\n" + selfClosingTagInputWithSlashHtml + "\n");
+
+		logger.log(Level.INFO, " **** generated js  **** ");
+
+		System.out.println(convertService.convert(selfClosingTagInputWithSlashHtml).replace("\n", ""));
+	
 
 		logger.log(Level.INFO, " **** ***********************  **** ");
 
-		String selfClosingTagsNotWorking2 = "<input type=\"text\">\r\n" + "<img src=\"#URL\" alt=\"image\"/>";
+		String selfClosingTagInputWithSlashHtml2 = "<input type=\"text\"/>\r\n" + "<img src=\"#URL\" alt=\"image\">";
 
-		logger.log(Level.INFO, "\n\n" + selfClosingTagsNotWorking2 + "\n");
+		logger.log(Level.INFO, "\n\n" + selfClosingTagInputWithSlashHtml2 + "\n");
 
-		logger.log(Level.INFO, " **** generated js:  **** ");
+		logger.log(Level.INFO, " **** generated js  **** ");
 
-		System.out.println(convertService.convert(selfClosingTagsNotWorking2));
-
-		/* When input ends with a slash /> at the end of the tag , it works */
-		logger.log(Level.INFO, " **** Self closing tags working  **** ");
-
-		String selfClosingTagsWorking = "<input type=\"text\"/>\r\n" + "<img src=\"#URL\" alt=\"image\"/>";
-
-		logger.log(Level.INFO, "\n\n" + selfClosingTagsWorking + "\n");
-
-		logger.log(Level.INFO, " **** generated js:  **** ");
-
-		System.out.println(convertService.convert(selfClosingTagsWorking));
-
-		logger.log(Level.INFO, " **** ***********************  **** ");
-
-		String selfClosingTagsWorking2 = "<input type=\"text\"/>\r\n" + "<img src=\"#URL\" alt=\"image\">";
-
-		logger.log(Level.INFO, "\n\n" + selfClosingTagsWorking2 + "\n");
-
-		logger.log(Level.INFO, " **** generated js:  **** ");
-
-		System.out.println(convertService.convert(selfClosingTagsWorking2));
+		System.out.println(convertService.convert(selfClosingTagInputWithSlashHtml2));
+	
 
 	}
 

--- a/src/main/java/com/osscameroon/jsgenerator/service/ConvertServiceImpl.java
+++ b/src/main/java/com/osscameroon/jsgenerator/service/ConvertServiceImpl.java
@@ -220,17 +220,83 @@ public class ConvertServiceImpl implements ConvertService {
 		return addAttributeToElement(attributes, innerHTML, tag, generatedCode);
 
 	}
+	
+	/*
+	 * TODO: We have to add the update info (date, author,...) everywhere when it is needed
+	 * */
+	
+	/**
+	 * Updated on April 30th, 2022 by Fanon Jupkwo
+	 * */
 
 	private String appendChild(JsElement jsElement) {
+		
 		StringBuilder generatedCode = new StringBuilder();
+		
+		
+		/*
+		 * Please, think twice before deleting this log, it helps to understand what is going on under the hood.
+		 * It is really helpful to understand that there is a bug in Jsoup library.
+		 * 
+		 * Let's take an example, 
+		 * 
+		 * 
+		 * <input type="text"> <img src="#URL" alt="image">
+		 * 
+		 * ------------------------------------------------------
+		 * 
+		 * <input type="text"/> <img src="#URL" alt="image">
+		 * 
+		 * Jsoup considers  <input> and <input/> as self closing tags.
+		 * 
+		 * Consequently, they should not have children.
+		 * 
+		 * But there is something weird with Jsoup, <input> could have children if there is another html tag close to its position, this behavior is incorrect. 
+		 * <input/> could not, this is correct.
+		 * 
+		 * How could you verify that ? Just run the tests and look the logs. 
+		 * 
+		 * Here is the previous  code with self closing tag issue : https://github.com/osscameroon/js-generator/tree/self-closing-tag-issue
+		 * 
+		 * In order to correct that, we created a condition to test if the tag is self closing then we do nothing. 
+		 * If it is not self closing and if there are children, only then we append children.
+		 * 
+		 *  Before this change, the only condition was if the element has children. 
+		     This is why we had self closing tag with the possibility of having children, that's completely wrong.
+		   
+		 *  Useful links:
+		 * 
+		 *  https://www.educba.com/types-of-tags-in-html/
+		
+		    https://www.tutorialstonight.com/self-closing-tags-in-html.php#:~:text=HTML%20Self%20Closing%20Tag,%2C%20etc.
 
-		if (jsElement.getElement().children().size() > 0) {
-			for (Element child : jsElement.getElement().children()) {
-				generatedCode.append(jsElement.getElement().tagName()).append(".appendChild(").append(child.tagName())
-						.append(");\n");
+		 * */
+		
+		logger.log(Level.FINEST, " **** Analyze jsElement :"+jsElement.getElement().tag().getName()
+				+" -> isEmpty : "+ jsElement.getElement().tag().isEmpty()
+				+" -> isSelfClosing : "+ jsElement.getElement().tag().isSelfClosing() 
+				+" -> isKnown : "+ jsElement.getElement().tag().isKnownTag()
+				+ " -> hasChild : "+ jsElement.getElement().childrenSize()+ " **** ");
+		
+		if(jsElement.getElement().tag().isSelfClosing()) {
+			
+		}else {
+			
+			if (jsElement.getElement().children().size() > 0) {
+				
+				
+				for (Element child : jsElement.getElement().children()) {
+					
+					
+					generatedCode.append(jsElement.getElement().tagName()).append(".appendChild(").append(child.tagName())
+							.append(");\n");
+				}
 			}
-		}
 
+			
+		}
+		
+		
 		return generatedCode.toString();
 	}
 

--- a/src/test/java/com/osscameroon/jsgenerator/service/ConvertServiceTest.java
+++ b/src/test/java/com/osscameroon/jsgenerator/service/ConvertServiceTest.java
@@ -14,6 +14,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.osscameroon.jsgenerator.model.JsElement;
+
 /**
  * Provide methods to test {@link ConvertServiceImpl} methods.
  *
@@ -140,81 +142,101 @@ public class ConvertServiceTest {
 	@Test
 	public void testSelfClosingTagWithoutSlashIssue()  {
 		
-		/*
-		 * Use Regex to replace self closing tag without slash with slashin order to follow the rule of jsoup
-		 * */
-		
-		// Self closing tags
-
-		/*
+	
+		/*  Self closing tags Issue
+		 * 
+		 * <input type="text"> <img src="#URL" alt="image">
+		 * 
+		 * ------------------------------------------------------
+		 * 
+		 * <input type="text"/> <img src="#URL" alt="image">
+		 * 
 		 * When input doesn't end with a slash /> at the end of the tag , it doesn't
-		 * work. img looks like a child of input but it's false.
+		 * work because img looks like a child of input but it's false.
+		 * 
+		 * Jsoup considers the ones with and without a slash /> at the end as self closing tags. 
+		 * 
+		 * But the one without slash could have children and that's false.
+		 * 
+		 * To correct that, we updated the method String appendChild(JsElement jsElement) in ConvertServiceImpl, just take a look at it.
+		 * 
+		 * Useful links:
+		 * 
+		 *  https://www.educba.com/types-of-tags-in-html/
+		
+		https://www.tutorialstonight.com/self-closing-tags-in-html.php#:~:text=HTML%20Self%20Closing%20Tag,%2C%20etc.
+
+		 * 
 		 */
 
-		/* Jsoup consider self closing tag as the one with a slash /> at the end */
-
+		
 		/*
-		 * The program should throw an exception if a non self closing tag like div is
-		 * considered as self closing tag ?
-		 */
+		 * When there is an element with child, the program creates the Js Children variables before parent.
+		 * In this case, it creates img before input
+		 * */
 
-		logger.log(Level.INFO, " **** Self closing tags Not working  **** ");
+		logger.log(Level.INFO, " **** Self closing tags without slash   **** ");
 
-		String selfClosingTagsNotWorkingHtml = "<input type=\"text\">\r\n" + "<img src=\"#URL\" alt=\"image\">";
+		String selfClosingTagInputWithoutSlashHtml = "<input type=\"text\">\r\n" + "<img src=\"#URL\" alt=\"image\">";
+			
+		String selfClosingTagInputWithoutSlashJs="var img = document.createElement(\"img\");img.setAttribute(\"src\", \"#URL\");img.setAttribute(\"alt\", \"image\");var input = document.createElement(\"input\");input.setAttribute(\"type\", \"text\");";
 		
-		String selfClosingTagsNotWorkingJs ="var img = document.createElement(\"img\");img.setAttribute(\"src\", \"#URL\");img.setAttribute(\"alt\", \"image\");var input = document.createElement(\"input\");input.setAttribute(\"type\", \"text\");input.appendChild(img);";
-
-		String selfClosingTagsWorkingJs ="var input = document.createElement(\"input\");input.setAttribute(\"type\", \"text\");var img = document.createElement(\"img\");img.setAttribute(\"src\", \"#URL\");img.setAttribute(\"alt\", \"image\");";
-
-		
-		logger.log(Level.INFO, "\n\n" + selfClosingTagsNotWorkingHtml + "\n");
+		logger.log(Level.INFO, "\n\n" + selfClosingTagInputWithoutSlashHtml + "\n");
 
 		logger.log(Level.INFO, " **** generated js without line breaks:  **** ");
 		
 
-		System.out.println(convertService.convert(selfClosingTagsNotWorkingHtml).replace("\n", ""));
+		System.out.println(convertService.convert(selfClosingTagInputWithoutSlashHtml).replace("\n", ""));
 		
-		assertEquals("error", selfClosingTagsWorkingJs, convertService.convert(selfClosingTagsNotWorkingHtml).replace("\n", ""));
+		assertEquals("error", selfClosingTagInputWithoutSlashJs, convertService.convert(selfClosingTagInputWithoutSlashHtml).replace("\n", ""));
 
 		logger.log(Level.INFO, " **** ***********************  **** ");
 
-		String selfClosingTagsNotWorkingHtml2 = "<input type=\"text\">\r\n" + "<img src=\"#URL\" alt=\"image\"/>";
+		String selfClosingTagInputWithoutSlashHtml2 = "<input type=\"text\">\r\n" + "<img src=\"#URL\" alt=\"image\"/>";
 
-		logger.log(Level.INFO, "\n\n" + selfClosingTagsNotWorkingHtml2 + "\n");
-
-		logger.log(Level.INFO, " **** generated js without line breaks:  **** ");
-
-		System.out.println(convertService.convert(selfClosingTagsNotWorkingHtml2).replace("\n", ""));
-		
-		assertEquals("error", selfClosingTagsWorkingJs, convertService.convert(selfClosingTagsNotWorkingHtml2).replace("\n", ""));
-
-
-		/* When input ends with a slash /> at the end of the tag , it works */
-		logger.log(Level.INFO, " **** Self closing tags working  **** ");
-
-		String selfClosingTagsWorkingHtml = "<input type=\"text\"/>\r\n" + "<img src=\"#URL\" alt=\"image\"/>";
-		
-		
-		logger.log(Level.INFO, "\n\n" + selfClosingTagsWorkingHtml + "\n");
+		logger.log(Level.INFO, "\n\n" + selfClosingTagInputWithoutSlashHtml2 + "\n");
 
 		logger.log(Level.INFO, " **** generated js without line breaks:  **** ");
 
-		System.out.println(convertService.convert(selfClosingTagsWorkingHtml).replace("\n", ""));
+		System.out.println(convertService.convert(selfClosingTagInputWithoutSlashHtml2).replace("\n", ""));
 		
-		assertEquals("error", selfClosingTagsWorkingJs, convertService.convert(selfClosingTagsWorkingHtml).replace("\n", ""));
+		assertEquals("error", selfClosingTagInputWithoutSlashJs, convertService.convert(selfClosingTagInputWithoutSlashHtml2).replace("\n", ""));
+
+
+		/* When input ends with a slash /> at the end of the tag , it works perfectly. */
+		
+		/*
+		 * When there is an element without child, the program creates the Js variable of this element  before moving forward.
+		 * In this case, it creates input before img
+		 * */
+		logger.log(Level.INFO, " **** Self closing tags with slash  **** ");
+
+		String selfClosingTagInputWithSlashHtml = "<input type=\"text\"/>\r\n" + "<img src=\"#URL\" alt=\"image\"/>";
+		
+		String selfClosingTagInputWithSlashJs ="var input = document.createElement(\"input\");input.setAttribute(\"type\", \"text\");var img = document.createElement(\"img\");img.setAttribute(\"src\", \"#URL\");img.setAttribute(\"alt\", \"image\");";
+
+		
+		
+		logger.log(Level.INFO, "\n\n" + selfClosingTagInputWithSlashHtml + "\n");
+
+		logger.log(Level.INFO, " **** generated js without line breaks:  **** ");
+
+		System.out.println(convertService.convert(selfClosingTagInputWithSlashHtml).replace("\n", ""));
+		
+		assertEquals("error", selfClosingTagInputWithSlashJs, convertService.convert(selfClosingTagInputWithSlashHtml).replace("\n", ""));
 
 
 		logger.log(Level.INFO, " **** ***********************  **** ");
 
-		String selfClosingTagsWorkingHtml2 = "<input type=\"text\"/>\r\n" + "<img src=\"#URL\" alt=\"image\">";
+		String selfClosingTagInputWithSlashHtml2 = "<input type=\"text\"/>\r\n" + "<img src=\"#URL\" alt=\"image\">";
 
-		logger.log(Level.INFO, "\n\n" + selfClosingTagsWorkingHtml2 + "\n");
+		logger.log(Level.INFO, "\n\n" + selfClosingTagInputWithSlashHtml2 + "\n");
 
 		logger.log(Level.INFO, " **** generated js without line breaks:  **** ");
 
-		System.out.println(convertService.convert(selfClosingTagsWorkingHtml2).replace("\n", ""));
+		System.out.println(convertService.convert(selfClosingTagInputWithSlashHtml2).replace("\n", ""));
 		
-		assertEquals("error", selfClosingTagsWorkingJs, convertService.convert(selfClosingTagsWorkingHtml2).replace("\n", ""));
+		assertEquals("error", selfClosingTagInputWithSlashJs, convertService.convert(selfClosingTagInputWithSlashHtml2).replace("\n", ""));
 
 
 


### PR DESCRIPTION
Issue : https://github.com/osscameroon/js-generator/issues/41

**It is very important  to understand that there is a bug related to self closing tag in [Jsoup library](https://github.com/jhy/jsoup). It looks like self closing tags could have children, that's wrong.**

Let's take 2 examples : 

`<input type="text"> <img src="#URL" alt="image">`

`<input type="text"/> <img src="#URL" alt="image">`
		  
**Jsoup considers  `<input>` and `<input/>` as self closing tags. Consequently, they should not have children.**
		  
But there is something weird with Jsoup, `<input>` could have children if there is another html tag close to its position, this behavior is incorrect. `<input/>` could not, this is correct.

In the first example, Jsoup considers `<img>` as a child of `<input>`, this is false.  In the second example, Jsoup doesn't  consider `<img>` as a child of `<input/>`, this is true.

How could you verify that ? Just run the tests and look the logs. 

Here is the previous  code with self closing tag issue : https://github.com/osscameroon/js-generator/blob/self-closing-tag-issue/src/main/java/com/osscameroon/jsgenerator/service/ConvertServiceImpl.java

```
	private String appendChild(JsElement jsElement) {
		StringBuilder generatedCode = new StringBuilder();

		if (jsElement.getElement().children().size() > 0) {
			for (Element child : jsElement.getElement().children()) {
				generatedCode.append(jsElement.getElement().tagName()).append(".appendChild(").append(child.tagName())
						.append(");\n");
			}
		}

		return generatedCode.toString();
	}

```
		
In order to correct that, we created a condition to test if the tag is self closing then we do nothing. If it is not self closing and if there are children, only then we append children. Before this change, the only condition was if the element has children as you can see below.

This is why we had self closing tag with the possibility of having children, that's completely wrong.

```
	private String appendChild(JsElement jsElement) {
		
		StringBuilder generatedCode = new StringBuilder();
		
		
		/*
		 * Please, think twice before deleting this log, it helps to understand what is going on under the hood.
		 * It is really helpful to understand that there is a bug in Jsoup library.
		 * 
		 * Let's take an example, 
		 * 
		 * 
		 * <input type="text"> <img src="#URL" alt="image">
		 * 
		 * ------------------------------------------------------
		 * 
		 * <input type="text"/> <img src="#URL" alt="image">
		 * 
		 * Jsoup considers  <input> and <input/> as self closing tags.
		 * 
		 * Consequently, they should not have children.
		 * 
		 * But there is something weird with Jsoup, <input> could have children if there is another html tag close to its position, this behavior is incorrect. 
		 * <input/> could not, this is correct.
		 * 
		 * How could you verify that ? Just run the tests and look the logs. 
		 * 
		 * Here is the previous  code with self closing tag issue : https://github.com/osscameroon/js-generator/tree/self-closing-tag-issue
		 * 
		 * In order to correct that, we created a condition to test if the tag is self closing then we do nothing. 
		 * If it is not self closing and if there are children, only then we append children.
		 * 
		 *  Before this change, the only condition was if the element has children. 
		     This is why we had self closing tag with the possibility of having children, that's completely wrong.
		   
		 *  Useful links:
		 * 
		 *  https://www.educba.com/types-of-tags-in-html/
		
		    https://www.tutorialstonight.com/self-closing-tags-in-html.php#:~:text=HTML%20Self%20Closing%20Tag,%2C%20etc.

		 * */
		
		logger.log(Level.FINEST, " **** Analyze jsElement :"+jsElement.getElement().tag().getName()
				+" -> isEmpty : "+ jsElement.getElement().tag().isEmpty()
				+" -> isSelfClosing : "+ jsElement.getElement().tag().isSelfClosing() 
				+" -> isKnown : "+ jsElement.getElement().tag().isKnownTag()
				+ " -> hasChild : "+ jsElement.getElement().childrenSize()+ " **** ");
		
		if(jsElement.getElement().tag().isSelfClosing()) {
			
		}else {
			
			if (jsElement.getElement().children().size() > 0) {
				
				
				for (Element child : jsElement.getElement().children()) {
					
					
					generatedCode.append(jsElement.getElement().tagName()).append(".appendChild(").append(child.tagName())
							.append(");\n");
				}
			}

			
		}
		
		
		return generatedCode.toString();
	}
```

Useful links:

https://www.educba.com/types-of-tags-in-html/
		
https://www.tutorialstonight.com/self-closing-tags-in-html.php#:~:text=HTML%20Self%20Closing%20Tag,%2C%20etc.