### PR TITLE
Add Example in README and trailing space after using trim() method on TexTNode value

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Actually, it's just a console program but gradually we will build a Maven/Gradle
 
 https://osscameroon.github.io/js-generator/
 
-# Examples
+# Example
 
 This is one example to show you how things work, there are more examples in our [Wiki](https://github.com/osscameroon/js-generator/wiki).
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 # About
 
 The goal is to generate JavaScript  from HTML  following the JavaScript DOM structure.
-Sometimes, we forget how to write JavaScript to build dynamic web apps. Even if we know JS, it happens that we don't always have enough time to generate JS code from a big HTML code. Thus, the goal of this project is helping developers gaining time by producing JS code as Output based on HTML as Input. This project will be very useful for beginners learning HTML and JavaScript. Also, it will help more experienced developers whenever they want to use JS.
+Sometimes, we forget how to write JavaScript to build dynamic web apps. Even if we know JS, it happens that we don't always have enough time to generate JS from a big HTML code. Thus, the goal of this project is helping developers gaining time by producing JS code as Output based on HTML as Input. This project will be very useful for beginners learning HTML and JavaScript. Also, it will help more experienced developers whenever they want to use JS.
 
 The project is based on [jsoup  library, a java html parser](https://jsoup.org/) / [Jsoup GitHub Repository](https://github.com/jhy/jsoup/). It's all about using Nodes to generate JavaScript. 
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ https://osscameroon.github.io/js-generator/
 
 This example gives you a big picture, our [Wiki](https://github.com/osscameroon/js-generator/wiki) will provide more explanation on how things work under the hood.
 
-Let's suppose we are building an Html page starting with this initial code [JSFiddle](https://jsfiddle.net/a23j0nxf/):
+Let's suppose we are building an HTML page starting with this initial code [JSFiddle](https://jsfiddle.net/a23j0nxf/):
 
 ```html
 <!DOCTYPE html>

--- a/README.md
+++ b/README.md
@@ -17,6 +17,214 @@ Actually, it's just a console program but gradually we will build a Maven/Gradle
 
 https://osscameroon.github.io/js-generator/
 
+# Examples
+
+This is one example to show you how things work, there are more examples in our [Wiki](https://github.com/osscameroon/js-generator/wiki).
+
+Let's suppose we are building an Html page and this is the initial code:
+
+```html
+<!DOCTYPE html>
+<html>
+  <body>
+
+    <div id="divtest">
+
+    </div>
+
+  </body>
+</html>
+```
+Then, we want to add more data inside the **`div tag with id "divtest"`**. It's possible to do it manually but we don't want. Our goal is to make it dynamic with Javascript. We want to create Javascript variables that we'll use for whatever we want.
+
+This is the html code we'll add into divtest:
+```html
+
+ <div>
+  
+    <h1>Open Source Society Cameroon</h1>
+    
+    <p>jsgenerator : Translating from Html to Js</p>
+    
+    <h2>About</h2>
+    
+    
+    
+    <p>
+      
+          The goal is to generate Javascript from HTML following the JavaScript DOM structure. Sometimes, we forget how to use javascript to build dynamic web apps. Thus, the goal of this project is helping developers gaining time by producing javascript code as output based on html as input. This project will be very useful for beginners learning html and javascript.
+
+    </p>
+      
+    <p>
+      
+          The project is based on <a href="https://jsoup.org/">jsoup library, a java html parser</a> / <a href="https://github.com/jhy/jsoup/">Jsoup GitHub Repository</a> .It's all about using nodes to generate javascript.
+      
+    </p>
+      
+    <p>
+      
+          Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to  <a href="https://translate.google.com/">Google Translate</a>.
+
+    </p>
+      
+</div>
+
+```
+
+This is Js ouput we get after translating :
+
+```javascript
+let h1 = document.createElement("h1");
+h1.appendChild(document.createTextNode("Open Source Society Cameroon"));
+
+let p = document.createElement("p");
+p.appendChild(document.createTextNode("jsgenerator : Translating from Html to Js"));
+
+let h2 = document.createElement("h2");
+h2.appendChild(document.createTextNode("About"));
+
+let a = document.createElement("a");
+a.setAttribute("href", "https://jsoup.org/");
+a.appendChild(document.createTextNode("jsoup library, a java html parser"));
+
+let a_ = document.createElement("a");
+a_.setAttribute("href", "https://github.com/jhy/jsoup/");
+a_.appendChild(document.createTextNode("Jsoup GitHub Repository"));
+
+let a__ = document.createElement("a");
+a__.setAttribute("href", " https://translate.google.com/");
+a__.appendChild(document.createTextNode("Google Translate"));
+
+let p_ = document.createElement("p");
+p_.appendChild(document.createTextNode("The goal is to generate Javascript from HTML following the JavaScript DOM structure. Sometimes, we forget how to use javascript to build dynamic web apps. Thus, the goal of this project is helping developers gaining time by producing javascript code as output based on html as input. This project will be very useful for beginners learning html and javascript.
+
+The project is based on"));
+p_.appendChild(document.createTextNode("/"));
+p_.appendChild(document.createTextNode(".It's all about using nodes to generate javascript.
+
+Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to"));
+p_.appendChild(document.createTextNode("."));
+p_.appendChild(a);
+p_.appendChild(a_);
+p_.appendChild(a__);
+
+let div = document.createElement("div");
+div.appendChild(h1);
+div.appendChild(p);
+div.appendChild(h2);
+div.appendChild(p_);
+```
+
+It's time to link our output to our initial html code
+
+```
+let divtest = document.getElementById("divtest");
+
+divtest.appendChild(div);
+```
+In order to test that it works, just compare the results on https://jsfiddle.net/
+
+## Result 1
+
+```
+<!DOCTYPE html>
+<html>
+<body>
+
+<div id="divtest">
+
+  <div>
+  
+    <h1>Open Source Society Cameroon</h1>
+    
+    <p>jsgenerator : Translating from Html to Js</p>
+    
+    <h2>About</h2>
+    
+    <p>
+    The goal is to generate Javascript from HTML following the JavaScript DOM structure. Sometimes, we forget how to use javascript to build dynamic web apps. Thus, the goal of this project is helping developers gaining time by producing javascript code as output based on html as input. This project will be very useful for beginners learning html and javascript.
+
+The project is based on <a href="https://jsoup.org/">jsoup library, a java html parser</a> / <a href="https://github.com/jhy/jsoup/">Jsoup GitHub Repository</a> .It's all about using nodes to generate javascript.
+
+Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to  <a href=" https://translate.google.com/">Google Translate</a> .
+    </p>
+    
+  </div>
+  
+</div>
+
+</body>
+</html>
+```
+
+## Result 2
+
+Html code
+
+```
+<!DOCTYPE html>
+<html>
+<body>
+
+<div id="divtest">
+
+</div>
+
+</body>
+</html>
+
+```
+Js code
+
+```
+let h1 = document.createElement("h1");
+h1.appendChild(document.createTextNode("Open Source Society Cameroon"));
+
+let p = document.createElement("p");
+p.appendChild(document.createTextNode("jsgenerator : Translating from Html to Js"));
+
+let h2 = document.createElement("h2");
+h2.appendChild(document.createTextNode("About"));
+
+let a = document.createElement("a");
+a.setAttribute("href", "https://jsoup.org/");
+a.appendChild(document.createTextNode("jsoup library, a java html parser"));
+
+let a_ = document.createElement("a");
+a_.setAttribute("href", "https://github.com/jhy/jsoup/");
+a_.appendChild(document.createTextNode("Jsoup GitHub Repository"));
+
+let a__ = document.createElement("a");
+a__.setAttribute("href", " https://translate.google.com/");
+a__.appendChild(document.createTextNode("Google Translate"));
+
+let p_ = document.createElement("p");
+p_.appendChild(document.createTextNode("The goal is to generate Javascript from HTML following the JavaScript DOM structure. Sometimes, we forget how to use javascript to build dynamic web apps. Thus, the goal of this project is helping developers gaining time by producing javascript code as output based on html as input. This project will be very useful for beginners learning html and javascript.
+
+The project is based on"));
+p_.appendChild(document.createTextNode("/"));
+p_.appendChild(document.createTextNode(".It's all about using nodes to generate javascript.
+
+Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to"));
+p_.appendChild(document.createTextNode("."));
+p_.appendChild(a);
+p_.appendChild(a_);
+p_.appendChild(a__);
+
+let div = document.createElement("div");
+div.appendChild(h1);
+div.appendChild(p);
+div.appendChild(h2);
+div.appendChild(p_);
+
+// It's time to link our output to our initial html code
+
+let divtest = document.getElementById("divtest");
+
+divtest.appendChild(div);
+```
+
 # Code Info
 
 Language: JAVA

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Let's suppose we are building an HTML page starting with this initial code [JSFi
   </body>
 </html>
 ```
-Then, we want to add more data inside the **`div tag with id "divtest"`**. It's possible to do it manually but we don't want that. Our goal is to make it dynamic with JavaScript. We want to create JavaScript variables that we'll use for whatever we want.
+Then, we want to add more data inside the **`div tag with id "divtest"`**. It's possible to do it manually but we don't want that. **Our goal is to make it dynamic with JavaScript. We want to create JavaScript variables that we'll use for whatever we want.**
 
 This is the HTML code we'll add to divtest [JSFiddle](https://jsfiddle.net/xyrqa05c/):
 ```html

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ divtest.appendChild(div);
 ```
 In order to test that it works, just compare the results on https://jsfiddle.net/
 
-## Result 1
+## Expected Result
 
 ```html
 <!DOCTYPE html>
@@ -229,9 +229,9 @@ In order to test that it works, just compare the results on https://jsfiddle.net
 </html>
 ```
 
-## Result 2
+## Equivalent Result with the initial html code and the Js generated code
 
-Html code
+### Initial Html Code
 
 ```html
 <!DOCTYPE html>
@@ -245,7 +245,7 @@ Html code
   </body>
 </html>
 ```
-Js code
+### Javascript Generated Code
 
 ```javascript
 let h1 = document.createElement("h1");

--- a/README.md
+++ b/README.md
@@ -72,8 +72,33 @@ This is the html code we'll add into divtest:
 </div>
 
 ```
+Let's go to the [Main Class JSGenerator](https://github.com/osscameroon/js-generator/blob/main/src/main/java/com/osscameroon/jsgenerator/JSGenerator.java#L87), just copy the html code into the variable named **html** then run the program.
 
-This is Js ouput we get after translating :
+```java
+    /**
+     * Converts built-in code from Html to Js and prints the result.
+     */
+     
+    static void convertAndPrintBuiltInCodeFromHtmlToJs() {
+
+	// Use log instead of system.out.println to show steps
+	logger.log(Level.INFO, " **** Converting built-in code from html to js **** ");
+	logger.log(Level.INFO, " **** Html to convert:  **** ");
+  
+  
+  // Copy the html code into the variable named **html** then run the program.
+  
+  String html="";
+  
+	logger.log(Level.INFO, "\n\n" + html + "\n");
+
+	logger.log(Level.INFO, " **** generated js:  **** "+ "\n");
+
+	System.out.println(convertService.convert(html));
+    }
+```
+
+This is Js ouput we get after translating from the console :
 
 ```javascript
 let h1 = document.createElement("h1");

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Let's go to the [Main Class JSGenerator](https://github.com/osscameroon/js-gener
     }
 ```
 
-This is Js ouput we get after translating from the console :
+Js ouput we get after translating from the console :
 
 ```javascript
 let h1 = document.createElement("h1");
@@ -153,7 +153,7 @@ div.appendChild(p___);
 
 It's time to link our output to our initial html code
 
-```
+```javascript
 let divtest = document.getElementById("divtest");
 
 divtest.appendChild(div);
@@ -162,34 +162,47 @@ In order to test that it works, just compare the results on https://jsfiddle.net
 
 ## Result 1
 
-```
+```html
 <!DOCTYPE html>
 <html>
-<body>
+  <body>
 
-<div id="divtest">
-
-  <div>
-  
-    <h1>Open Source Society Cameroon</h1>
+    <div id="divtest">
     
-    <p>jsgenerator : Translating from Html to Js</p>
-    
-    <h2>About</h2>
-    
-    <p>
-    The goal is to generate Javascript from HTML following the JavaScript DOM structure. Sometimes, we forget how to use javascript to build dynamic web apps. Thus, the goal of this project is helping developers gaining time by producing javascript code as output based on html as input. This project will be very useful for beginners learning html and javascript.
+       <div>
 
-The project is based on <a href="https://jsoup.org/">jsoup library, a java html parser</a> / <a href="https://github.com/jhy/jsoup/">Jsoup GitHub Repository</a> .It's all about using nodes to generate javascript.
+          <h1>Open Source Society Cameroon</h1>
 
-Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to  <a href=" https://translate.google.com/">Google Translate</a> .
-    </p>
-    
-  </div>
-  
-</div>
+          <p>jsgenerator : Translating from Html to Js</p>
 
-</body>
+          <h2>About</h2>
+
+          <p>
+
+                The goal is to generate Javascript from HTML following the JavaScript DOM structure. 
+                Sometimes, we forget how to use javascript to build dynamic web apps. 
+                Thus, the goal of this project is helping developers gaining time by producing javascript code as output based on html as input. 
+                This project will be very useful for beginners learning html and javascript.
+
+          </p>
+
+          <p>
+
+                The project is based on <a href="https://jsoup.org/">jsoup library, a java html parser</a> / <a href="https://github.com/jhy/jsoup/">Jsoup GitHub Repository</a> .It's all about using nodes to generate javascript.
+
+          </p>
+
+          <p>
+
+                Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to  <a href="https://translate.google.com/">Google Translate</a>.
+
+          </p>
+
+      </div>
+
+    </div>
+
+  </body>
 </html>
 ```
 
@@ -197,22 +210,22 @@ Actually, it's just a console program but gradually we will build a Maven/Gradle
 
 Html code
 
-```
+```html
 <!DOCTYPE html>
 <html>
-<body>
+  <body>
 
-<div id="divtest">
+    <div id="divtest">
 
-</div>
+    </div>
 
-</body>
+  </body>
 </html>
-
 ```
 Js code
 
-```
+```javascript
+
 let h1 = document.createElement("h1");
 h1.appendChild(document.createTextNode("Open Source Society Cameroon"));
 
@@ -222,6 +235,12 @@ p.appendChild(document.createTextNode("jsgenerator : Translating from Html to Js
 let h2 = document.createElement("h2");
 h2.appendChild(document.createTextNode("About"));
 
+let p_ = document.createElement("p");
+p_.appendChild(document.createTextNode("The goal is to generate Javascript from HTML following the JavaScript DOM structure. 
+          Sometimes, we forget how to use javascript to build dynamic web apps. 
+          Thus, the goal of this project is helping developers gaining time by producing javascript code as output based on html as input. 
+          This project will be very useful for beginners learning html and javascript."));
+
 let a = document.createElement("a");
 a.setAttribute("href", "https://jsoup.org/");
 a.appendChild(document.createTextNode("jsoup library, a java html parser"));
@@ -230,28 +249,30 @@ let a_ = document.createElement("a");
 a_.setAttribute("href", "https://github.com/jhy/jsoup/");
 a_.appendChild(document.createTextNode("Jsoup GitHub Repository"));
 
+let p__ = document.createElement("p");
+p__.appendChild(document.createTextNode("The project is based on"));
+p__.appendChild(a);
+p__.appendChild(document.createTextNode("/"));
+p__.appendChild(a_);
+p__.appendChild(document.createTextNode(".It's all about using nodes to generate javascript."));
+
 let a__ = document.createElement("a");
-a__.setAttribute("href", " https://translate.google.com/");
+a__.setAttribute("href", "https://translate.google.com/");
 a__.appendChild(document.createTextNode("Google Translate"));
 
-let p_ = document.createElement("p");
-p_.appendChild(document.createTextNode("The goal is to generate Javascript from HTML following the JavaScript DOM structure. Sometimes, we forget how to use javascript to build dynamic web apps. Thus, the goal of this project is helping developers gaining time by producing javascript code as output based on html as input. This project will be very useful for beginners learning html and javascript.
-
-The project is based on"));
-p_.appendChild(document.createTextNode("/"));
-p_.appendChild(document.createTextNode(".It's all about using nodes to generate javascript.
-
-Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to"));
-p_.appendChild(document.createTextNode("."));
-p_.appendChild(a);
-p_.appendChild(a_);
-p_.appendChild(a__);
+let p___ = document.createElement("p");
+p___.appendChild(document.createTextNode("Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to"));
+p___.appendChild(a__);
+p___.appendChild(document.createTextNode("."));
 
 let div = document.createElement("div");
 div.appendChild(h1);
 div.appendChild(p);
 div.appendChild(h2);
 div.appendChild(p_);
+div.appendChild(p__);
+div.appendChild(p___);
+
 
 // It's time to link our output to our initial html code
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ This is the html code we'll add into divtest:
     
     <h2>About</h2>
     
-    
-    
     <p>
       
-          The goal is to generate Javascript from HTML following the JavaScript DOM structure. Sometimes, we forget how to use javascript to build dynamic web apps. Thus, the goal of this project is helping developers gaining time by producing javascript code as output based on html as input. This project will be very useful for beginners learning html and javascript.
+          The goal is to generate Javascript from HTML following the JavaScript DOM structure. 
+          Sometimes, we forget how to use javascript to build dynamic web apps. 
+          Thus, the goal of this project is helping developers gaining time by producing javascript code as output based on html as input. 
+          This project will be very useful for beginners learning html and javascript.
 
     </p>
       

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 # About
 
-The goal is to generate Javascript  from HTML  following the JavaScript DOM structure.
-Sometimes, we forget how to use javascript to build dynamic web apps. Thus, the goal of this project is helping developers gaining time by producing javascript code as output based on html as input. This project will be very useful for beginners learning html and javascript.
+The goal is to generate JavaScript  from HTML  following the JavaScript DOM structure.
+Sometimes, we forget how to write JavaScript code to build dynamic web apps. Thus, the goal of this project is helping developers gaining time by producing JS code as output based on html as input. This project will be very useful for beginners learning html and javascript. Also, it will help more experienced developers whenever they want to use JS.
 
-The project is based on [jsoup  library, a java html parser](https://jsoup.org/) / [Jsoup GitHub Repository](https://github.com/jhy/jsoup/) . It's all about using nodes to generate javascript. 
+The project is based on [jsoup  library, a java html parser](https://jsoup.org/) / [Jsoup GitHub Repository](https://github.com/jhy/jsoup/). It's all about using nodes to generate JavaScript. 
 
-Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to Google Translate : https://translate.google.com/.
+Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to JS, an app similar to Google Translate : https://translate.google.com/.
 
 # Project Documentation
 
@@ -19,9 +19,9 @@ https://osscameroon.github.io/js-generator/
 
 # Example
 
-This is one example to show you how things work, there are more examples in our [Wiki](https://github.com/osscameroon/js-generator/wiki).
+This is one example to give you a big picture, our [Wiki](https://github.com/osscameroon/js-generator/wiki) will provide more explanation on how things work under the hood.
 
-Let's suppose we are building an Html page by starting with this initial code [JSFiddle](https://jsfiddle.net/a23j0nxf/).
+Let's suppose we are building an Html page by starting with this initial code [JSFiddle](https://jsfiddle.net/a23j0nxf/):
 
 ```html
 <!DOCTYPE html>
@@ -35,9 +35,9 @@ Let's suppose we are building an Html page by starting with this initial code [J
   </body>
 </html>
 ```
-Then, we want to add more data inside the **`div tag with id "divtest"`**. It's possible to do it manually but we don't want. Our goal is to make it dynamic with Javascript. We want to create Javascript variables that we'll use for whatever we want.
+Then, we want to add more data inside the **`div tag with id "divtest"`**. It's possible to do it manually but we don't want that. Our goal is to make it dynamic with JavaScript. We want to create JavaScript variables that we'll use for whatever we want.
 
-This is the html code we'll add into divtest [JSFiddle](https://jsfiddle.net/xyrqa05c/) :
+This is the html code we'll add into divtest [JSFiddle](https://jsfiddle.net/xyrqa05c/):
 ```html
 
  <div>
@@ -110,7 +110,7 @@ It's possible to choose between **let** or **var** to declare your javascript va
     }
 ```
 
-Js ouput we get after translating from the console :
+JS ouput we get after translating from the console:
 
 ```javascript
 
@@ -164,7 +164,7 @@ div.appendChild(p___);
 
 ```
 
-It's time to link our output to our initial html code
+It's time to link our output to our initial html code:
 
 ```javascript
 let divtest = document.getElementById("divtest");
@@ -221,7 +221,7 @@ In order to test that it works, just compare the results on https://jsfiddle.net
 </html>
 ```
 
-## Equivalent Result with the initial html code and the Js generated code
+## Equivalent Result with the initial Html code and the JS generated code
 
 [JSFiddle](https://jsfiddle.net/yaoqt24x/)
 
@@ -239,7 +239,7 @@ In order to test that it works, just compare the results on https://jsfiddle.net
   </body>
 </html>
 ```
-### Javascript Generated Code
+### JavaScript Generated Code
 
 ```javascript
 
@@ -298,7 +298,7 @@ let divtest = document.getElementById("divtest");
 
 divtest.appendChild(div);
 ```
-We hope this example makes you better understand this project. If not enough, the [Wiki](https://github.com/osscameroon/js-generator/wiki) will provide more examples.
+We hope this example makes you better understand this project. In a real project, you might want to use the generated Js code for whatever you want, it's up to you. If not enough, the [Wiki](https://github.com/osscameroon/js-generator/wiki) will provide more explanation on how things work under the hood.
 
 # Code Info
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ This is the html code we'll add into divtest:
 ```
 Let's go to the [Main Class JSGenerator](https://github.com/osscameroon/js-generator/blob/main/src/main/java/com/osscameroon/jsgenerator/JSGenerator.java#L87), just copy the html code into the variable named **html** then run the program.
 
+It's possible to choose between **let** or **var** to declare your javascript variables as you can see here. We'll use **let** for this example.
+
+
+```java
+    // Just choose between VAR or LET for your variable declarations
+
+    // static ConvertService convertService = new ConvertServiceImpl(JsVariableDeclaration.VAR);
+    
+    static ConvertService convertService = new ConvertServiceImpl(JsVariableDeclaration.LET);
+```
+
+
 ```java
     /**
      * Converts built-in code from Html to Js and prints the result.
@@ -280,6 +292,7 @@ let divtest = document.getElementById("divtest");
 
 divtest.appendChild(div);
 ```
+We hope this example makes you better understand this project. If not enough, the [Wiki](https://github.com/osscameroon/js-generator/wiki) will provide more examples.
 
 # Code Info
 

--- a/README.md
+++ b/README.md
@@ -113,44 +113,45 @@ It's possible to choose between **let** or **var** to declare your javascript va
 Js ouput we get after translating from the console :
 
 ```javascript
+
 let h1 = document.createElement("h1");
-h1.appendChild(document.createTextNode("Open Source Society Cameroon"));
+h1.appendChild(document.createTextNode("Open Source Society Cameroon "));
 
 let p = document.createElement("p");
-p.appendChild(document.createTextNode("jsgenerator : Translating from Html to Js"));
+p.appendChild(document.createTextNode("jsgenerator : Translating from Html to Js "));
 
 let h2 = document.createElement("h2");
-h2.appendChild(document.createTextNode("About"));
+h2.appendChild(document.createTextNode("About "));
 
 let p_ = document.createElement("p");
 p_.appendChild(document.createTextNode("The goal is to generate Javascript from HTML following the JavaScript DOM structure. 
           Sometimes, we forget how to use javascript to build dynamic web apps. 
           Thus, the goal of this project is helping developers gaining time by producing javascript code as output based on html as input. 
-          This project will be very useful for beginners learning html and javascript."));
+          This project will be very useful for beginners learning html and javascript. "));
 
 let a = document.createElement("a");
 a.setAttribute("href", "https://jsoup.org/");
-a.appendChild(document.createTextNode("jsoup library, a java html parser"));
+a.appendChild(document.createTextNode("jsoup library, a java html parser "));
 
 let a_ = document.createElement("a");
 a_.setAttribute("href", "https://github.com/jhy/jsoup/");
-a_.appendChild(document.createTextNode("Jsoup GitHub Repository"));
+a_.appendChild(document.createTextNode("Jsoup GitHub Repository "));
 
 let p__ = document.createElement("p");
-p__.appendChild(document.createTextNode("The project is based on"));
+p__.appendChild(document.createTextNode("The project is based on "));
 p__.appendChild(a);
-p__.appendChild(document.createTextNode("/"));
+p__.appendChild(document.createTextNode("/ "));
 p__.appendChild(a_);
-p__.appendChild(document.createTextNode(".It's all about using nodes to generate javascript."));
+p__.appendChild(document.createTextNode(".It's all about using nodes to generate javascript. "));
 
 let a__ = document.createElement("a");
 a__.setAttribute("href", "https://translate.google.com/");
-a__.appendChild(document.createTextNode("Google Translate"));
+a__.appendChild(document.createTextNode("Google Translate "));
 
 let p___ = document.createElement("p");
-p___.appendChild(document.createTextNode("Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to"));
+p___.appendChild(document.createTextNode("Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to "));
 p___.appendChild(a__);
-p___.appendChild(document.createTextNode("."));
+p___.appendChild(document.createTextNode(". "));
 
 let div = document.createElement("div");
 div.appendChild(h1);
@@ -237,44 +238,45 @@ In order to test that it works, just compare the results on https://jsfiddle.net
 ### Javascript Generated Code
 
 ```javascript
+
 let h1 = document.createElement("h1");
-h1.appendChild(document.createTextNode("Open Source Society Cameroon"));
+h1.appendChild(document.createTextNode("Open Source Society Cameroon "));
 
 let p = document.createElement("p");
-p.appendChild(document.createTextNode("jsgenerator : Translating from Html to Js"));
+p.appendChild(document.createTextNode("jsgenerator : Translating from Html to Js "));
 
 let h2 = document.createElement("h2");
-h2.appendChild(document.createTextNode("About"));
+h2.appendChild(document.createTextNode("About "));
 
 let p_ = document.createElement("p");
 p_.appendChild(document.createTextNode("The goal is to generate Javascript from HTML following the JavaScript DOM structure. 
           Sometimes, we forget how to use javascript to build dynamic web apps. 
           Thus, the goal of this project is helping developers gaining time by producing javascript code as output based on html as input. 
-          This project will be very useful for beginners learning html and javascript."));
+          This project will be very useful for beginners learning html and javascript. "));
 
 let a = document.createElement("a");
 a.setAttribute("href", "https://jsoup.org/");
-a.appendChild(document.createTextNode("jsoup library, a java html parser"));
+a.appendChild(document.createTextNode("jsoup library, a java html parser "));
 
 let a_ = document.createElement("a");
 a_.setAttribute("href", "https://github.com/jhy/jsoup/");
-a_.appendChild(document.createTextNode("Jsoup GitHub Repository"));
+a_.appendChild(document.createTextNode("Jsoup GitHub Repository "));
 
 let p__ = document.createElement("p");
-p__.appendChild(document.createTextNode("The project is based on"));
+p__.appendChild(document.createTextNode("The project is based on "));
 p__.appendChild(a);
-p__.appendChild(document.createTextNode("/"));
+p__.appendChild(document.createTextNode("/ "));
 p__.appendChild(a_);
-p__.appendChild(document.createTextNode(".It's all about using nodes to generate javascript."));
+p__.appendChild(document.createTextNode(".It's all about using nodes to generate javascript. "));
 
 let a__ = document.createElement("a");
 a__.setAttribute("href", "https://translate.google.com/");
-a__.appendChild(document.createTextNode("Google Translate"));
+a__.appendChild(document.createTextNode("Google Translate "));
 
 let p___ = document.createElement("p");
-p___.appendChild(document.createTextNode("Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to"));
+p___.appendChild(document.createTextNode("Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to "));
 p___.appendChild(a__);
-p___.appendChild(document.createTextNode("."));
+p___.appendChild(document.createTextNode(". "));
 
 let div = document.createElement("div");
 div.appendChild(h1);
@@ -283,6 +285,7 @@ div.appendChild(h2);
 div.appendChild(p_);
 div.appendChild(p__);
 div.appendChild(p___);
+
 
 
 // It's time to link our output to our initial html code

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 # About
 
 The goal is to generate JavaScript  from HTML  following the JavaScript DOM structure.
-Sometimes, we forget how to write JavaScript code to build dynamic web apps. Thus, the goal of this project is helping developers gaining time by producing JS code as output based on html as input. This project will be very useful for beginners learning html and javascript. Also, it will help more experienced developers whenever they want to use JS.
+Sometimes, we forget how to write JavaScript to build dynamic web apps. Even if we know JS, it happens that we don't always have enough time to generate JS code from a big HTML code. Thus, the goal of this project is helping developers gaining time by producing JS code as Output based on HTML as Input. This project will be very useful for beginners learning HTML and JavaScript. Also, it will help more experienced developers whenever they want to use JS.
 
-The project is based on [jsoup  library, a java html parser](https://jsoup.org/) / [Jsoup GitHub Repository](https://github.com/jhy/jsoup/). It's all about using nodes to generate JavaScript. 
+The project is based on [jsoup  library, a java html parser](https://jsoup.org/) / [Jsoup GitHub Repository](https://github.com/jhy/jsoup/). It's all about using Nodes to generate JavaScript. 
 
-Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to JS, an app similar to Google Translate : https://translate.google.com/.
+**Actually, it's just a console program but gradually we will build a Maven/Gradle Library, a Web & Desktop App and a CLI (Command Line Interface) tool translating from HTML to JS.**
 
 # Project Documentation
 
@@ -19,9 +19,9 @@ https://osscameroon.github.io/js-generator/
 
 # Example
 
-This is one example to give you a big picture, our [Wiki](https://github.com/osscameroon/js-generator/wiki) will provide more explanation on how things work under the hood.
+This example gives you a big picture, our [Wiki](https://github.com/osscameroon/js-generator/wiki) will provide more explanation on how things work under the hood.
 
-Let's suppose we are building an Html page by starting with this initial code [JSFiddle](https://jsfiddle.net/a23j0nxf/):
+Let's suppose we are building an Html page starting with this initial code [JSFiddle](https://jsfiddle.net/a23j0nxf/):
 
 ```html
 <!DOCTYPE html>
@@ -37,7 +37,7 @@ Let's suppose we are building an Html page by starting with this initial code [J
 ```
 Then, we want to add more data inside the **`div tag with id "divtest"`**. It's possible to do it manually but we don't want that. Our goal is to make it dynamic with JavaScript. We want to create JavaScript variables that we'll use for whatever we want.
 
-This is the html code we'll add into divtest [JSFiddle](https://jsfiddle.net/xyrqa05c/):
+This is the HTML code we'll add to divtest [JSFiddle](https://jsfiddle.net/xyrqa05c/):
 ```html
 
  <div>
@@ -72,9 +72,9 @@ This is the html code we'll add into divtest [JSFiddle](https://jsfiddle.net/xyr
 </div>
 
 ```
-Let's go to the [Main Class JSGenerator](https://github.com/osscameroon/js-generator/blob/main/src/main/java/com/osscameroon/jsgenerator/JSGenerator.java#L87), just copy the html code into the variable named **html** then run the program.
+Let's go to the [Main Class JSGenerator](https://github.com/osscameroon/js-generator/blob/main/src/main/java/com/osscameroon/jsgenerator/JSGenerator.java#L87), just copy the HTML code into the variable named **html** then run the program.
 
-It's possible to choose between **let** or **var** to declare your javascript variables as you can see here. We'll use **let** for this example.
+It's possible to choose between **let** or **var** to declare your JavaScript variables as you can see here. We'll use **let** for this example:
 
 
 ```java
@@ -164,7 +164,7 @@ div.appendChild(p___);
 
 ```
 
-It's time to link our output to our initial html code:
+It's time to link our output to our initial HTML code:
 
 ```javascript
 let divtest = document.getElementById("divtest");
@@ -221,11 +221,11 @@ In order to test that it works, just compare the results on https://jsfiddle.net
 </html>
 ```
 
-## Equivalent Result with the initial Html code and the JS generated code
+## Equivalent Result with the Initial HTML and JS generated code
 
 [JSFiddle](https://jsfiddle.net/yaoqt24x/)
 
-### Initial Html Code
+### Initial HTML Code
 
 ```html
 <!DOCTYPE html>
@@ -298,7 +298,7 @@ let divtest = document.getElementById("divtest");
 
 divtest.appendChild(div);
 ```
-We hope this example makes you better understand this project. In a real project, you might want to use the generated Js code for whatever you want, it's up to you. If not enough, the [Wiki](https://github.com/osscameroon/js-generator/wiki) will provide more explanation on how things work under the hood.
+We hope this example makes you better understand this project. In a real project, you might want to use the generated JS code for whatever you want, it's up to you. If not enough, the [Wiki](https://github.com/osscameroon/js-generator/wiki) will provide more explanation on how things work under the hood.
 
 # Code Info
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Let's go to the [Main Class JSGenerator](https://github.com/osscameroon/js-gener
 	logger.log(Level.INFO, " **** Html to convert:  **** ");
   
   
-  // Copy the html code into the variable named **html** then run the program.
+  // Copy the html code into the variable named html then run the program.
   
   String html="";
   

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Let's suppose we are building an Html page by starting with this initial code [J
 ```
 Then, we want to add more data inside the **`div tag with id "divtest"`**. It's possible to do it manually but we don't want. Our goal is to make it dynamic with Javascript. We want to create Javascript variables that we'll use for whatever we want.
 
-This is the html code we'll add into divtest:
+This is the html code we'll add into divtest [JSFiddle](https://jsfiddle.net/xyrqa05c/) :
 ```html
 
  <div>
@@ -175,6 +175,8 @@ In order to test that it works, just compare the results on https://jsfiddle.net
 
 ## Expected Result
 
+[JSFiddle](https://jsfiddle.net/pyahn1fc/)
+
 ```html
 <!DOCTYPE html>
 <html>
@@ -220,6 +222,8 @@ In order to test that it works, just compare the results on https://jsfiddle.net
 ```
 
 ## Equivalent Result with the initial html code and the Js generated code
+
+[JSFiddle](https://jsfiddle.net/yaoqt24x/)
 
 ### Initial Html Code
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![codecov](https://codecov.io/gh/osscameroon/js-generator/branch/main/graph/badge.svg?token=QJEBIRY8JJ)](https://codecov.io/gh/osscameroon/js-generator)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-# jsgenerator : Translating from Html to Js
+# jsgenerator : Translating from HTML to JS
 
 # About
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ https://osscameroon.github.io/js-generator/
 
 This is one example to show you how things work, there are more examples in our [Wiki](https://github.com/osscameroon/js-generator/wiki).
 
-Let's suppose we are building an Html page and this is the initial code:
+Let's suppose we are building an Html page by starting with this initial code [JSFiddle](https://jsfiddle.net/a23j0nxf/).
 
 ```html
 <!DOCTYPE html>

--- a/README.md
+++ b/README.md
@@ -123,14 +123,10 @@ let h2 = document.createElement("h2");
 h2.appendChild(document.createTextNode("About"));
 
 let p_ = document.createElement("p");
-p_.appendChild(document.createTextNode("
-      
-          The goal is to generate Javascript from HTML following the JavaScript DOM structure. 
+p_.appendChild(document.createTextNode("The goal is to generate Javascript from HTML following the JavaScript DOM structure. 
           Sometimes, we forget how to use javascript to build dynamic web apps. 
           Thus, the goal of this project is helping developers gaining time by producing javascript code as output based on html as input. 
-          This project will be very useful for beginners learning html and javascript.
-
-    "));
+          This project will be very useful for beginners learning html and javascript."));
 
 let a = document.createElement("a");
 a.setAttribute("href", "https://jsoup.org/");
@@ -141,28 +137,20 @@ a_.setAttribute("href", "https://github.com/jhy/jsoup/");
 a_.appendChild(document.createTextNode("Jsoup GitHub Repository"));
 
 let p__ = document.createElement("p");
-p__.appendChild(document.createTextNode("
-      
-          The project is based on "));
+p__.appendChild(document.createTextNode("The project is based on"));
 p__.appendChild(a);
-p__.appendChild(document.createTextNode(" / "));
+p__.appendChild(document.createTextNode("/"));
 p__.appendChild(a_);
-p__.appendChild(document.createTextNode(" .It's all about using nodes to generate javascript.
-      
-    "));
+p__.appendChild(document.createTextNode(".It's all about using nodes to generate javascript."));
 
 let a__ = document.createElement("a");
 a__.setAttribute("href", "https://translate.google.com/");
 a__.appendChild(document.createTextNode("Google Translate"));
 
 let p___ = document.createElement("p");
-p___.appendChild(document.createTextNode("
-      
-          Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to  "));
+p___.appendChild(document.createTextNode("Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to"));
 p___.appendChild(a__);
-p___.appendChild(document.createTextNode(".
-
-    "));
+p___.appendChild(document.createTextNode("."));
 
 let div = document.createElement("div");
 div.appendChild(h1);
@@ -171,6 +159,7 @@ div.appendChild(h2);
 div.appendChild(p_);
 div.appendChild(p__);
 div.appendChild(p___);
+
 
 ```
 
@@ -258,14 +247,10 @@ let h2 = document.createElement("h2");
 h2.appendChild(document.createTextNode("About"));
 
 let p_ = document.createElement("p");
-p_.appendChild(document.createTextNode("
-      
-          The goal is to generate Javascript from HTML following the JavaScript DOM structure. 
+p_.appendChild(document.createTextNode("The goal is to generate Javascript from HTML following the JavaScript DOM structure. 
           Sometimes, we forget how to use javascript to build dynamic web apps. 
           Thus, the goal of this project is helping developers gaining time by producing javascript code as output based on html as input. 
-          This project will be very useful for beginners learning html and javascript.
-
-    "));
+          This project will be very useful for beginners learning html and javascript."));
 
 let a = document.createElement("a");
 a.setAttribute("href", "https://jsoup.org/");
@@ -276,28 +261,20 @@ a_.setAttribute("href", "https://github.com/jhy/jsoup/");
 a_.appendChild(document.createTextNode("Jsoup GitHub Repository"));
 
 let p__ = document.createElement("p");
-p__.appendChild(document.createTextNode("
-      
-          The project is based on "));
+p__.appendChild(document.createTextNode("The project is based on"));
 p__.appendChild(a);
-p__.appendChild(document.createTextNode(" / "));
+p__.appendChild(document.createTextNode("/"));
 p__.appendChild(a_);
-p__.appendChild(document.createTextNode(" .It's all about using nodes to generate javascript.
-      
-    "));
+p__.appendChild(document.createTextNode(".It's all about using nodes to generate javascript."));
 
 let a__ = document.createElement("a");
 a__.setAttribute("href", "https://translate.google.com/");
 a__.appendChild(document.createTextNode("Google Translate"));
 
 let p___ = document.createElement("p");
-p___.appendChild(document.createTextNode("
-      
-          Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to  "));
+p___.appendChild(document.createTextNode("Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to"));
 p___.appendChild(a__);
-p___.appendChild(document.createTextNode(".
-
-    "));
+p___.appendChild(document.createTextNode("."));
 
 let div = document.createElement("div");
 div.appendChild(h1);

--- a/README.md
+++ b/README.md
@@ -123,10 +123,14 @@ let h2 = document.createElement("h2");
 h2.appendChild(document.createTextNode("About"));
 
 let p_ = document.createElement("p");
-p_.appendChild(document.createTextNode("The goal is to generate Javascript from HTML following the JavaScript DOM structure. 
+p_.appendChild(document.createTextNode("
+      
+          The goal is to generate Javascript from HTML following the JavaScript DOM structure. 
           Sometimes, we forget how to use javascript to build dynamic web apps. 
           Thus, the goal of this project is helping developers gaining time by producing javascript code as output based on html as input. 
-          This project will be very useful for beginners learning html and javascript."));
+          This project will be very useful for beginners learning html and javascript.
+
+    "));
 
 let a = document.createElement("a");
 a.setAttribute("href", "https://jsoup.org/");
@@ -137,20 +141,28 @@ a_.setAttribute("href", "https://github.com/jhy/jsoup/");
 a_.appendChild(document.createTextNode("Jsoup GitHub Repository"));
 
 let p__ = document.createElement("p");
-p__.appendChild(document.createTextNode("The project is based on"));
+p__.appendChild(document.createTextNode("
+      
+          The project is based on "));
 p__.appendChild(a);
-p__.appendChild(document.createTextNode("/"));
+p__.appendChild(document.createTextNode(" / "));
 p__.appendChild(a_);
-p__.appendChild(document.createTextNode(".It's all about using nodes to generate javascript."));
+p__.appendChild(document.createTextNode(" .It's all about using nodes to generate javascript.
+      
+    "));
 
 let a__ = document.createElement("a");
 a__.setAttribute("href", "https://translate.google.com/");
 a__.appendChild(document.createTextNode("Google Translate"));
 
 let p___ = document.createElement("p");
-p___.appendChild(document.createTextNode("Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to"));
+p___.appendChild(document.createTextNode("
+      
+          Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to  "));
 p___.appendChild(a__);
-p___.appendChild(document.createTextNode("."));
+p___.appendChild(document.createTextNode(".
+
+    "));
 
 let div = document.createElement("div");
 div.appendChild(h1);
@@ -159,7 +171,6 @@ div.appendChild(h2);
 div.appendChild(p_);
 div.appendChild(p__);
 div.appendChild(p___);
-
 
 ```
 
@@ -237,7 +248,6 @@ Html code
 Js code
 
 ```javascript
-
 let h1 = document.createElement("h1");
 h1.appendChild(document.createTextNode("Open Source Society Cameroon"));
 
@@ -248,10 +258,14 @@ let h2 = document.createElement("h2");
 h2.appendChild(document.createTextNode("About"));
 
 let p_ = document.createElement("p");
-p_.appendChild(document.createTextNode("The goal is to generate Javascript from HTML following the JavaScript DOM structure. 
+p_.appendChild(document.createTextNode("
+      
+          The goal is to generate Javascript from HTML following the JavaScript DOM structure. 
           Sometimes, we forget how to use javascript to build dynamic web apps. 
           Thus, the goal of this project is helping developers gaining time by producing javascript code as output based on html as input. 
-          This project will be very useful for beginners learning html and javascript."));
+          This project will be very useful for beginners learning html and javascript.
+
+    "));
 
 let a = document.createElement("a");
 a.setAttribute("href", "https://jsoup.org/");
@@ -262,20 +276,28 @@ a_.setAttribute("href", "https://github.com/jhy/jsoup/");
 a_.appendChild(document.createTextNode("Jsoup GitHub Repository"));
 
 let p__ = document.createElement("p");
-p__.appendChild(document.createTextNode("The project is based on"));
+p__.appendChild(document.createTextNode("
+      
+          The project is based on "));
 p__.appendChild(a);
-p__.appendChild(document.createTextNode("/"));
+p__.appendChild(document.createTextNode(" / "));
 p__.appendChild(a_);
-p__.appendChild(document.createTextNode(".It's all about using nodes to generate javascript."));
+p__.appendChild(document.createTextNode(" .It's all about using nodes to generate javascript.
+      
+    "));
 
 let a__ = document.createElement("a");
 a__.setAttribute("href", "https://translate.google.com/");
 a__.appendChild(document.createTextNode("Google Translate"));
 
 let p___ = document.createElement("p");
-p___.appendChild(document.createTextNode("Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to"));
+p___.appendChild(document.createTextNode("
+      
+          Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to  "));
 p___.appendChild(a__);
-p___.appendChild(document.createTextNode("."));
+p___.appendChild(document.createTextNode(".
+
+    "));
 
 let div = document.createElement("div");
 div.appendChild(h1);

--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ p.appendChild(document.createTextNode("jsgenerator : Translating from Html to Js
 let h2 = document.createElement("h2");
 h2.appendChild(document.createTextNode("About"));
 
+let p_ = document.createElement("p");
+p_.appendChild(document.createTextNode("The goal is to generate Javascript from HTML following the JavaScript DOM structure. 
+          Sometimes, we forget how to use javascript to build dynamic web apps. 
+          Thus, the goal of this project is helping developers gaining time by producing javascript code as output based on html as input. 
+          This project will be very useful for beginners learning html and javascript."));
+
 let a = document.createElement("a");
 a.setAttribute("href", "https://jsoup.org/");
 a.appendChild(document.createTextNode("jsoup library, a java html parser"));
@@ -118,28 +124,31 @@ let a_ = document.createElement("a");
 a_.setAttribute("href", "https://github.com/jhy/jsoup/");
 a_.appendChild(document.createTextNode("Jsoup GitHub Repository"));
 
+let p__ = document.createElement("p");
+p__.appendChild(document.createTextNode("The project is based on"));
+p__.appendChild(a);
+p__.appendChild(document.createTextNode("/"));
+p__.appendChild(a_);
+p__.appendChild(document.createTextNode(".It's all about using nodes to generate javascript."));
+
 let a__ = document.createElement("a");
-a__.setAttribute("href", " https://translate.google.com/");
+a__.setAttribute("href", "https://translate.google.com/");
 a__.appendChild(document.createTextNode("Google Translate"));
 
-let p_ = document.createElement("p");
-p_.appendChild(document.createTextNode("The goal is to generate Javascript from HTML following the JavaScript DOM structure. Sometimes, we forget how to use javascript to build dynamic web apps. Thus, the goal of this project is helping developers gaining time by producing javascript code as output based on html as input. This project will be very useful for beginners learning html and javascript.
-
-The project is based on"));
-p_.appendChild(document.createTextNode("/"));
-p_.appendChild(document.createTextNode(".It's all about using nodes to generate javascript.
-
-Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to"));
-p_.appendChild(document.createTextNode("."));
-p_.appendChild(a);
-p_.appendChild(a_);
-p_.appendChild(a__);
+let p___ = document.createElement("p");
+p___.appendChild(document.createTextNode("Actually, it's just a console program but gradually we will build a Maven/Gradle library then a web app translating from Html to Js, an app similar to"));
+p___.appendChild(a__);
+p___.appendChild(document.createTextNode("."));
 
 let div = document.createElement("div");
 div.appendChild(h1);
 div.appendChild(p);
 div.appendChild(h2);
 div.appendChild(p_);
+div.appendChild(p__);
+div.appendChild(p___);
+
+
 ```
 
 It's time to link our output to our initial html code

--- a/src/main/java/com/osscameroon/jsgenerator/service/ConvertServiceImpl.java
+++ b/src/main/java/com/osscameroon/jsgenerator/service/ConvertServiceImpl.java
@@ -443,9 +443,15 @@ public class ConvertServiceImpl implements ConvertService {
 
 			TextNode textNode = (TextNode) childNode;
 
+			/*
+			 * We concat trailing space because trim() removes all leading and trailing
+			 * spaces even the ones that are mandatory.
+			 *
+			 */
+
 			if (!textNode.isBlank()) {
 			    generatedCode.append(tag).append(".appendChild(document.createTextNode(\"")
-				    .append(textNode.toString().replace("\n", "").trim()).append("\"));\n");
+				    .append(textNode.toString().replace("\n", "").trim().concat(" ")).append("\"));\n");
 			}
 
 		    }


### PR DESCRIPTION
 We concat trailing space because trim() removes all leading and trailing spaces even the ones that are mandatory.
			