### PR TITLE
feat: support native cli build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,12 @@
 *.jsgenerator.js
+*.build_artifacts.txt
+/jsgenerator*
+!/jsgenerator-ante
+!/jsgenerator-api
+!/jsgenerator-core
+!/jsgenerator-desktop
+!/jsgenerator-test
+!/jsgenerator-web
 
 # Compiled class file
 *.class

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Translating files, stdin or inline from HTML to JS
 
 # Stack
 
-+ Java 11
++ Java 11 (or GraalVM JDK 11, for native CLI client)
 + Maven 3
 + Spring 5.3.22
 + Spring Boot 2.7.3
@@ -91,9 +91,12 @@ cd js-generator
 # 3. Tests & Build
 mvn clean package
 
-# 4. Browse through code
-# 5. Run CLI with --help and play with it
-# 6. Fork the project, build, test, open a pull request
+# 4. Build Native CLI (Requires GraalVM JDK 11)
+./cli-build.sh # if provided, first argument will be the file name (useful for version tagging) 
+
+# 5. Browse through code
+# 6. Run CLI with --help and play with it
+# 7. Fork the project, build, test, open a pull request
 ```
 
 Hello World, all your contributions are welcome! Don't hesitate to open an issue on this repository and/or create a pull

--- a/cli-build.sh
+++ b/cli-build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+set -euxo
+
+_NATIVE_DIRECTORY="$(mktemp --directory --tmpdir="$(dirname "$(realpath "$0")")/jsgenerator-cli/target" native-XXXXXX)"
+cat "$(dirname "$(realpath "$0")")/jsgenerator-cli/target/"*.original > "${_NATIVE_DIRECTORY}/jsgenerator-cli.jar"
+
+unzip ./jsgenerator-cli/target/*.jar -d "${_NATIVE_DIRECTORY}/"
+_CLASSPATH="$(find "${_NATIVE_DIRECTORY}/BOOT-INF/lib" | tr '\n' ':')"
+_CLASSPATH="${_NATIVE_DIRECTORY}/jsgenerator-cli.jar:${_CLASSPATH}:${_NATIVE_DIRECTORY}/BOOT-INF/classes"
+
+cp -R "${_NATIVE_DIRECTORY}/META-INF" "${_NATIVE_DIRECTORY}/BOOT-INF/classes"
+native-image \
+  "-H:Name=${1:-jsgenerator}" \
+  --class-path "${_CLASSPATH}" \
+  --module-path "${_CLASSPATH}" \
+  --module com.osscameroon.jsgenerator.cli/com.osscameroon.jsgenerator.cli.JsGeneratorCli


### PR DESCRIPTION
[toc]

# What's Inside

+ [x] Native CLI build (require GraalVM JDK 11)
+ [x] Native build steps documentation

# Personal Comments

While I cannot document everything that failed, here are a few things I noticed:

+ `jpackage` seems to have many platform-dependent options, which isn't a great way of working when targeting multiple platforms
+ `GraalVM` direct integration in the **pom.xml** doesn't add the self-module JAR to classpath and module (I couldn't find documentation to augment either)
+ `spring-native` build is easier to integrate but suffers the same challenge as previously

All of what precedes lead to this external script - **/cli-build.sh** - not integrated with **pom.xml**.

# Testing Environment

I am working on Linux (Ubuntu) and have tested this on my environment.

I will indulge contributors to help in testing on other platforms before merging :

+ [x] Linux (Ubuntu)
+ [ ] Windows
+ [ ] MacOS

# Noteworthy

> The **/cli-build.sh** is shell-friendly, not CMD, not Power-Shell. This means testing on windows may require a similar terminal (git-bash, cmder, etc).
>
> It should also be tested on Windows if building the native image in a shell-friendly encrionment results in a CMD-/Power-Shell-compliant executable.