### PR TITLE
[js-generator/86] fix: CVE-2022-36033 vulnerability in JSoup 1.14.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
-                <version>1.14.3</version>
+                <version>1.15.3</version>
             </dependency>
             <dependency>
                 <groupId>info.picocli</groupId>


### PR DESCRIPTION
+ fix osscameroon/js-generator#86