### PR TITLE
fix: prevent greetings failure on issues

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      issues: write
+      #issues: write
     steps:
     - uses: actions/first-interaction@v1
       with:


### PR DESCRIPTION
[Greetings action](https://github.com/osscameroon/js-generator/blob/main/.github/workflows/greetings.yml) failed when opening these issues:

https://github.com/osscameroon/js-generator/issues/136

https://github.com/osscameroon/js-generator/issues/135

_Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /node_modules/@octokit/graphql/index.js_

To know more: https://github.com/osscameroon/js-generator/actions/runs/3167828752/jobs/5158596113