### PR TITLE
fix: solve Resource not accessible by integration

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,11 +1,16 @@
 name: Greetings
-on: [pull_request, issues]
+#on: [pull_request, issues]
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
 jobs:
   greeting:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      issues: write
+    #permissions:
+      #pull-requests: write
+      #issues: write
     steps:
     - uses: actions/first-interaction@v1
     # At this moment, this GitHub Action has an issue: https://github.com/actions/first-interaction/issues/101


### PR DESCRIPTION
This PR https://github.com/osscameroon/js-generator/pull/150 failed with this message:

```
Adding message: Thanks for opening your first pull request 😊 ! We really appreciate your work. Happy Coding 🎉🎊 ! to pull request 150 
Error: Resource not accessible by integration
```

After investigating this first-interaction issue https://github.com/actions/first-interaction/issues/31 , we decided to apply these changes.

This article from Github also looks good: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/