### PR TITLE
feat: Migrate from Java 11 to 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,13 +16,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
+    - uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: 11
-        #cache: 'maven'
+        java-version: 17
+        # Given the fact that this is a multimodule project, build process will take long time so we activate caching
+        # To know more: https://maven.apache.org/extensions/maven-build-cache-extension/cache.html
+        cache: 'maven'
     - name: Build with Maven
     #To see the full stack trace of the errors, re-run Maven with the -e switch.
     #Re-run Maven using the -X switch to enable full debug logging.

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,10 @@
     <url>https://github.com/osscameroon/js-generator</url>
 
     <properties>
+        <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+
         <revision>0.0.1-SNAPSHOT</revision>
 
         <lomkok.version>1.18.24</lomkok.version>
@@ -30,8 +34,6 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
         <!-- GitHub OAuth token & server : Generating github  gh pages & maven project documents -->
         <github.global.server>github</github.global.server>
         <github.global.oauth2Token>${env.MAVEN_SITE_GITHUB_OAUTH_TOKEN}</github.global.oauth2Token>
@@ -127,9 +129,23 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- In order to avoid "Unsupported class file major version 61" error
+             we made this change related to asm. Version 61 means java 17
+             To know more:
+             https://stackoverflow.com/questions/71496063/maven-surefire-test-failed-unsupported-class-file-major-version-61
+             https://stackoverflow.com/questions/10382929/how-to-fix-java-lang-unsupportedclassversionerror-unsupported-major-minor-versi/11432195#11432195
+             -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.ow2.asm</groupId>
+                        <artifactId>asm</artifactId>
+                        <version>9.1</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <!-- Generating github gh pages & maven project documents  -->
             <plugin>


### PR DESCRIPTION
The main reason is the cross platform desktop app (running on Windows, Mac and Linux) we will build using JavaFX. It's possible to use other versions inferior than 17 but we will miss good documentation. We thought about using version 17 for the desktop module only then we decided to use it for all modules.