### PR TITLE
fix: build and update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ cd js-generator
 # 3. Tests & Build
 mvn clean package
 
-# 4. Build Native CLI (Requires GraalVM JDK 11, and a Linux-friendly shell, like Cmder)
+# 4. Build Native CLI (Requires GraalVM JDK 17, and a Linux-friendly shell, like Cmder)
 ./cli-build.sh # if provided, first argument will be the file name (useful for version tagging) 
 
 # 5. Browse through code

--- a/README.md
+++ b/README.md
@@ -95,7 +95,15 @@ Translating files, stdin or inline from HTML to JS
 
 # Stack
 
-+ Java 17 (or GraalVM JDK 17, for native CLI client)
++ JDK 17
+  > NOTE: For native build (CLI, for eg.), we use GraalVM with JDK 17.
+  > 
+  > Recent versions of GraalVM are not bundling `native-image` CLI by default.
+  > We are required to install is manually, by running:
+  > ```shell
+  > # Where `gu` is an executable bundled with GraalVM
+  > gu install native-image
+  > ```
 + Maven 3
 + Spring 5.3.22
 + Spring Boot 2.7.3
@@ -112,7 +120,7 @@ cd js-generator
 # 3. Tests & Build
 mvn clean package
 
-# 4. Build Native CLI (Requires GraalVM JDK 11)
+# 4. Build Native CLI (Requires GraalVM JDK 11, and a Linux-friendly shell, like Cmder)
 ./cli-build.sh # if provided, first argument will be the file name (useful for version tagging) 
 
 # 5. Browse through code

--- a/jsgenerator-cli/src/main/java/com/osscameroon/jsgenerator/cli/JsGeneratorCli.java
+++ b/jsgenerator-cli/src/main/java/com/osscameroon/jsgenerator/cli/JsGeneratorCli.java
@@ -4,6 +4,7 @@ import com.osscameroon.jsgenerator.cli.internal.CommandDefault;
 import com.osscameroon.jsgenerator.core.Converter;
 import com.osscameroon.jsgenerator.core.OutputStreamResolver;
 import com.osscameroon.jsgenerator.core.VariableNameStrategy;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -27,17 +28,17 @@ public class JsGeneratorCli {
     }
 
     @Bean
-    public OutputStreamResolver pathOutputFilenameResolver() {
+    public OutputStreamResolver pathOutputStreamResolver() {
         return OutputStreamResolver.ofPath();
     }
 
     @Bean
-    public OutputStreamResolver stdinOutputFilenameResolver() {
+    public OutputStreamResolver stdinOutputStreamResolver() {
         return OutputStreamResolver.ofStdin();
     }
 
     @Bean
-    public OutputStreamResolver inlineOutputFilenameResolver() {
+    public OutputStreamResolver inlineOutputStreamResolver() {
         return OutputStreamResolver.ofInline();
     }
 

--- a/jsgenerator-cli/src/main/java/module-info.java
+++ b/jsgenerator-cli/src/main/java/module-info.java
@@ -17,4 +17,6 @@ module com.osscameroon.jsgenerator.cli {
     requires spring.context;
     requires info.picocli;
     requires lombok;
+
+    requires spring.beans;
 }

--- a/jsgenerator-cli/src/main/resources/application.yaml
+++ b/jsgenerator-cli/src/main/resources/application.yaml
@@ -1,6 +1,6 @@
 logging:
   level:
-    root: OFF
+    root: error
 spring:
   main:
     banner-mode: off


### PR DESCRIPTION
# What's Inside?

+ [x] At the injection point, the parameter name must match the bean's name in the absence of explicit `@Qualifier` and multiple bean candidates based on the type
+ [x] `spring.beans` module need to be required in our module to enable Spring IoC bean qualifier automatic resolution
+ [x] Recent version of GraalVM (with JDK 17) are not coming with `native-image` executable: it needs manual installation - and the README has been updated to reflect that step