### PR TITLE
feat: allow custom root element selector

### DIFF
--- a/jsgenerator-cli/src/main/java/com/osscameroon/jsgenerator/cli/Command.java
+++ b/jsgenerator-cli/src/main/java/com/osscameroon/jsgenerator/cli/Command.java
@@ -8,8 +8,9 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 public interface Command extends Callable<Integer> {
-
     VariableDeclaration getVariableDeclaration();
+
+    String getTargetElementSelector();
 
     List<String> getInlineContents();
 

--- a/jsgenerator-cli/src/main/java/com/osscameroon/jsgenerator/cli/internal/CommandDefault.java
+++ b/jsgenerator-cli/src/main/java/com/osscameroon/jsgenerator/cli/internal/CommandDefault.java
@@ -54,6 +54,12 @@ public class CommandDefault implements Command, Valid {
     private String extension = ".jsgenerator.js";
 
     @Option(
+            names = {"-s", "--selector"},
+            defaultValue = ":root > body",
+            description = "Target element selector")
+    private String targetElementSelector = ":root > body";
+
+    @Option(
             names = "--stdin-pattern",
             defaultValue = "stdin{{ extension }}",
             description = "pattern for stdin output filenames")
@@ -104,12 +110,12 @@ public class CommandDefault implements Command, Valid {
         }
 
         // NOTE: Process paths
-        for (final var path : paths.stream().map(Path::toAbsolutePath).distinct().collect(toList())) {
+        for (final var path : paths.stream().map(Path::toAbsolutePath).distinct().toList()) {
             System.err.printf("\fTranslating: %s%n", path);
             converter.convert(
                     Files.newInputStream(path),
                     outputStream = resolvePathOutputStream(path),
-                    new Configuration(variableDeclaration));
+                    new Configuration(targetElementSelector, variableDeclaration));
             outputStream.flush();
             outputStream.close();
         }

--- a/jsgenerator-core/src/main/java/com/osscameroon/jsgenerator/core/Configuration.java
+++ b/jsgenerator-core/src/main/java/com/osscameroon/jsgenerator/core/Configuration.java
@@ -11,8 +11,13 @@ import lombok.NoArgsConstructor;
  * @since Oct 02, 2022 @t 09:55:40 WEST
  */
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class Configuration {
+    private String targetElementSelector = ":root > body";
     private VariableDeclaration variableDeclaration = VariableDeclaration.LET;
+
+    public Configuration(final VariableDeclaration variableDeclaration) {
+        this(":root > body", variableDeclaration);
+    }
 }

--- a/jsgenerator-core/src/main/java/com/osscameroon/jsgenerator/core/internal/ConverterDefault.java
+++ b/jsgenerator-core/src/main/java/com/osscameroon/jsgenerator/core/internal/ConverterDefault.java
@@ -42,7 +42,12 @@ public class ConverterDefault implements Converter {
 
         final var document = Jsoup.parse(content, xmlParser());
         final var writer = new OutputStreamWriter(outputStream);
-        visit(writer, "document", document.childNodes(), configuration);
+
+        final var selector = configuration.getTargetElementSelector();
+        final var variable = variableNameStrategy.nextName("targetElement");
+        final var keyword = resolveDeclarationKeyWord(configuration.getVariableDeclaration());
+        writer.write("%s %s = document.querySelector(`%s`);\n\n".formatted(keyword, variable, selector));
+        visit(writer, variable, document.childNodes(), configuration);
         writer.flush();
     }
 


### PR DESCRIPTION
# What's Inside?

+ [x] Allow custom selector of the target element
  > The rationale is that:
  > 1. Not all content is going into the body
  > 2. If the parsed HTML got 1,000 root elements, it is easier for the user to edit or customize a single target root element that adding manually after DOM code generation

# Notice

+ This PR follows https://github.com/osscameroon/js-generator/pull/165