### PR TITLE
fix: type based naming strategy must be scoped to single convert call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,12 @@
 *.jsgenerator.js
 *.build_artifacts.txt
 /jsgenerator*
-!/jsgenerator-ante
 !/jsgenerator-api
 !/jsgenerator-core
 !/jsgenerator-desktop
 !/jsgenerator-test
 !/jsgenerator-web
+!/jsgenerator-cli
 
 # Compiled class file
 *.class

--- a/jsgenerator-cli/src/main/java/com/osscameroon/jsgenerator/cli/BuiltinVariableNameStrategy.java
+++ b/jsgenerator-cli/src/main/java/com/osscameroon/jsgenerator/cli/BuiltinVariableNameStrategy.java
@@ -1,0 +1,25 @@
+package com.osscameroon.jsgenerator.cli;
+
+import com.osscameroon.jsgenerator.core.VariableNameStrategy;
+
+import java.util.function.Supplier;
+
+import static com.osscameroon.jsgenerator.core.VariableNameStrategy.ofRandom;
+import static com.osscameroon.jsgenerator.core.VariableNameStrategy.ofTypeBased;
+
+public enum BuiltinVariableNameStrategy implements Supplier<VariableNameStrategy> {
+    TYPE_BASED(ofTypeBased()),
+    RANDOM(ofRandom()),
+    ;
+
+    private final VariableNameStrategy variableNameStrategy;
+
+    BuiltinVariableNameStrategy(VariableNameStrategy variableNameStrategy) {
+        this.variableNameStrategy = variableNameStrategy;
+    }
+
+    @Override
+    public VariableNameStrategy get() {
+        return variableNameStrategy;
+    }
+}

--- a/jsgenerator-cli/src/main/java/com/osscameroon/jsgenerator/cli/Command.java
+++ b/jsgenerator-cli/src/main/java/com/osscameroon/jsgenerator/cli/Command.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 public interface Command extends Callable<Integer> {
+    BuiltinVariableNameStrategy getBuiltinVariableNameStrategy();
+
     VariableDeclaration getVariableDeclaration();
 
     String getTargetElementSelector();

--- a/jsgenerator-cli/src/main/java/com/osscameroon/jsgenerator/cli/Command.java
+++ b/jsgenerator-cli/src/main/java/com/osscameroon/jsgenerator/cli/Command.java
@@ -8,8 +8,9 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 public interface Command extends Callable<Integer> {
-
     VariableDeclaration getVariableDeclaration();
+
+    String getTargetElementSelector();
 
     List<String> getInlineContents();
 

--- a/jsgenerator-cli/src/main/java/com/osscameroon/jsgenerator/cli/JsGeneratorCli.java
+++ b/jsgenerator-cli/src/main/java/com/osscameroon/jsgenerator/cli/JsGeneratorCli.java
@@ -48,7 +48,7 @@ public class JsGeneratorCli {
 
     @Bean
     public Converter converter(final VariableNameStrategy typeBasedVariableNameStrategy) {
-        return Converter.of(typeBasedVariableNameStrategy);
+        return Converter.of();
     }
 
     @Bean

--- a/jsgenerator-cli/src/main/java/com/osscameroon/jsgenerator/cli/internal/CommandDefault.java
+++ b/jsgenerator-cli/src/main/java/com/osscameroon/jsgenerator/cli/internal/CommandDefault.java
@@ -1,5 +1,6 @@
 package com.osscameroon.jsgenerator.cli.internal;
 
+import com.osscameroon.jsgenerator.cli.BuiltinVariableNameStrategy;
 import com.osscameroon.jsgenerator.cli.Command;
 import com.osscameroon.jsgenerator.cli.Valid;
 import com.osscameroon.jsgenerator.core.Configuration;
@@ -19,10 +20,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static com.osscameroon.jsgenerator.cli.BuiltinVariableNameStrategy.TYPE_BASED;
 import static com.osscameroon.jsgenerator.core.OutputStreamResolver.*;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.stream.Collectors.toList;
 
 @Data
 @RequiredArgsConstructor
@@ -72,6 +73,12 @@ public class CommandDefault implements Command, Valid {
     private String pathPattern = format("{{ %s }}{{ %s }}", ORIGINAL, EXTENSION);
 
     @Option(
+            names = "--variable-name-generation-strategy",
+            defaultValue = "TYPE_BASED",
+            description = "Variable names generation strategy")
+    private BuiltinVariableNameStrategy builtinVariableNameStrategy = TYPE_BASED;
+
+    @Option(
             names = "--inline-pattern",
             defaultValue = "inline.{{ index }}{{ extension }}",
             description = "Pattern for inline output filename")
@@ -115,7 +122,7 @@ public class CommandDefault implements Command, Valid {
             converter.convert(
                     Files.newInputStream(path),
                     outputStream = resolvePathOutputStream(path),
-                    new Configuration(targetElementSelector, variableDeclaration));
+                    new Configuration(targetElementSelector, variableDeclaration, builtinVariableNameStrategy.get()));
             outputStream.flush();
             outputStream.close();
         }

--- a/jsgenerator-cli/src/main/java/com/osscameroon/jsgenerator/cli/internal/CommandDefault.java
+++ b/jsgenerator-cli/src/main/java/com/osscameroon/jsgenerator/cli/internal/CommandDefault.java
@@ -54,6 +54,12 @@ public class CommandDefault implements Command, Valid {
     private String extension = ".jsgenerator.js";
 
     @Option(
+            names = {"-s", "--selector"},
+            defaultValue = ":root > body",
+            description = "Target element selector")
+    private String targetElementSelector = ":root > body";
+
+    @Option(
             names = "--stdin-pattern",
             defaultValue = "stdin{{ extension }}",
             description = "pattern for stdin output filenames")
@@ -104,12 +110,12 @@ public class CommandDefault implements Command, Valid {
         }
 
         // NOTE: Process paths
-        for (final var path : paths.stream().map(Path::toAbsolutePath).distinct().collect(toList())) {
+        for (final var path : paths.stream().map(Path::toAbsolutePath).distinct().toList()) {
             System.err.printf("\fTranslating: %s%n", path);
             converter.convert(
                     Files.newInputStream(path),
                     outputStream = resolvePathOutputStream(path),
-                    new Configuration(variableDeclaration));
+                    new Configuration(targetElementSelector, variableDeclaration));
             outputStream.flush();
             outputStream.close();
         }

--- a/jsgenerator-core/src/main/java/com/osscameroon/jsgenerator/core/Configuration.java
+++ b/jsgenerator-core/src/main/java/com/osscameroon/jsgenerator/core/Configuration.java
@@ -4,6 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import static com.osscameroon.jsgenerator.core.VariableDeclaration.LET;
+import static com.osscameroon.jsgenerator.core.VariableNameStrategy.ofTypeBased;
+
 /**
  * Configuration
  *
@@ -15,9 +18,20 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class Configuration {
     private String targetElementSelector = ":root > body";
-    private VariableDeclaration variableDeclaration = VariableDeclaration.LET;
+    private VariableDeclaration variableDeclaration = LET;
+    private VariableNameStrategy variableNameStrategy = ofTypeBased();
 
     public Configuration(final VariableDeclaration variableDeclaration) {
-        this(":root > body", variableDeclaration);
+        this(variableDeclaration, ofTypeBased());
+    }
+
+    public Configuration(final String targetElementSelector,
+                         final VariableDeclaration variableDeclaration) {
+        this(targetElementSelector, variableDeclaration, ofTypeBased());
+    }
+
+    public Configuration(final VariableDeclaration variableDeclaration,
+                         final VariableNameStrategy variableNameStrategy) {
+        this(":root > body", variableDeclaration, variableNameStrategy);
     }
 }

--- a/jsgenerator-core/src/main/java/com/osscameroon/jsgenerator/core/Configuration.java
+++ b/jsgenerator-core/src/main/java/com/osscameroon/jsgenerator/core/Configuration.java
@@ -11,8 +11,13 @@ import lombok.NoArgsConstructor;
  * @since Oct 02, 2022 @t 09:55:40 WEST
  */
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class Configuration {
+    private String targetElementSelector = ":root > body";
     private VariableDeclaration variableDeclaration = VariableDeclaration.LET;
+
+    public Configuration(final VariableDeclaration variableDeclaration) {
+        this(":root > body", variableDeclaration);
+    }
 }

--- a/jsgenerator-core/src/main/java/com/osscameroon/jsgenerator/core/Converter.java
+++ b/jsgenerator-core/src/main/java/com/osscameroon/jsgenerator/core/Converter.java
@@ -14,7 +14,7 @@ public interface Converter {
 
     void convert(@NonNull final InputStream inputStream, @NonNull final OutputStream outputStream, @NonNull Configuration configuration);
 
-    static Converter of(@NonNull final VariableNameStrategy variableNameStrategy) {
-        return new ConverterDefault(variableNameStrategy);
+    static Converter of() {
+        return new ConverterDefault();
     }
 }

--- a/jsgenerator-core/src/main/java/com/osscameroon/jsgenerator/core/internal/ConverterDefault.java
+++ b/jsgenerator-core/src/main/java/com/osscameroon/jsgenerator/core/internal/ConverterDefault.java
@@ -42,7 +42,12 @@ public class ConverterDefault implements Converter {
 
         final var document = Jsoup.parse(content, xmlParser());
         final var writer = new OutputStreamWriter(outputStream);
-        visit(writer, "document", document.childNodes(), configuration);
+
+        final var selector = configuration.getTargetElementSelector();
+        final var variable = variableNameStrategy.nextName("targetElement");
+        final var keyword = resolveDeclarationKeyWord(configuration.getVariableDeclaration());
+        writer.write("%s %s = document.querySelector(`%s`);\n\n".formatted(keyword, variable, selector));
+        visit(writer, variable, document.childNodes(), configuration);
         writer.flush();
     }
 

--- a/jsgenerator-core/src/main/java/com/osscameroon/jsgenerator/core/internal/ConverterDefault.java
+++ b/jsgenerator-core/src/main/java/com/osscameroon/jsgenerator/core/internal/ConverterDefault.java
@@ -3,8 +3,6 @@ package com.osscameroon.jsgenerator.core.internal;
 import com.osscameroon.jsgenerator.core.Configuration;
 import com.osscameroon.jsgenerator.core.Converter;
 import com.osscameroon.jsgenerator.core.VariableDeclaration;
-import com.osscameroon.jsgenerator.core.VariableNameStrategy;
-import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.*;
@@ -17,13 +15,11 @@ import static java.lang.String.format;
 import static java.lang.String.join;
 import static org.jsoup.parser.Parser.xmlParser;
 
-@RequiredArgsConstructor
 public class ConverterDefault implements Converter {
     private static final List<String> BOOLEAN_ATTRIBUTES = List.of("allowfullscreen", "async", "autofocus",
             "autoplay", "checked", "controls", "default", "defer", "disabled", "formnovalidate", "ismap", "itemscope",
             "loop", "multiple", "muted", "nomodule", "novalidate", "open", "playsinline", "readonly", "required",
             "reversed", "selected", "truespeed", "contenteditable");
-    private final VariableNameStrategy variableNameStrategy;
 
     @Override
     @SneakyThrows
@@ -40,6 +36,7 @@ public class ConverterDefault implements Converter {
         // NOTE: There is nothing to do
         if (content.isBlank()) return;
 
+        final var variableNameStrategy = configuration.getVariableNameStrategy();
         final var document = Jsoup.parse(content, xmlParser());
         final var writer = new OutputStreamWriter(outputStream);
 
@@ -71,6 +68,7 @@ public class ConverterDefault implements Converter {
     }
 
     private void visit(Writer writer, String parent, Comment comment, Configuration configuration) throws IOException {
+        final var variableNameStrategy = configuration.getVariableNameStrategy();
         final var variable = variableNameStrategy.nextName("comment");
         String declarationKeyWord = resolveDeclarationKeyWord(configuration.getVariableDeclaration());
 
@@ -79,6 +77,7 @@ public class ConverterDefault implements Converter {
     }
 
     private void visit(Writer writer, String parent, TextNode textNode, Configuration configuration) throws IOException {
+        final var variableNameStrategy = configuration.getVariableNameStrategy();
         final var variable = variableNameStrategy.nextName("text");
         String declarationKeyWord = resolveDeclarationKeyWord(configuration.getVariableDeclaration());
 
@@ -87,6 +86,7 @@ public class ConverterDefault implements Converter {
     }
 
     private void visit(Writer writer, String parent, Element element, Configuration configuration) throws IOException {
+        final var variableNameStrategy = configuration.getVariableNameStrategy();
         final var variable = variableNameStrategy.nextName(element.tagName());
         String declarationKeyWord = resolveDeclarationKeyWord(configuration.getVariableDeclaration());
 
@@ -103,6 +103,8 @@ public class ConverterDefault implements Converter {
     }
 
     private void visitScriptNode(Writer writer, String parent, Element element, String variable, Configuration configuration) throws IOException {
+        final var variableNameStrategy = configuration.getVariableNameStrategy();
+
         if (element.attr(element.absUrl("type")).isBlank()) {
             writer.write(format("\r\n%s.type = `text/javascript`;\r\n", variable));
         }

--- a/jsgenerator-test/jsgenerator-test-core/src/test/java/com/osscameroon/jsgenerator/test/core/ConverterTest.java
+++ b/jsgenerator-test/jsgenerator-test-core/src/test/java/com/osscameroon/jsgenerator/test/core/ConverterTest.java
@@ -27,7 +27,7 @@ public class ConverterTest {
 
     @BeforeEach
     public void before() {
-        converter = Converter.of(VariableNameStrategy.ofTypeBased());
+        converter = Converter.of();
     }
 
     @ParameterizedTest
@@ -105,18 +105,16 @@ public class ConverterTest {
                 "%s div_000 = document.createElement('div');".formatted(keyword),
                 "div_000.setAttribute(`id`, `id-value`);",
                 "targetElement_000.appendChild(div_000);");
-        // TODO: Name counter need reset across calls to convert
         assertThat(convert("<details open></details>", new Configuration(variableDeclaration))).containsExactly(
-                "%s targetElement_001 = document.querySelector(`:root > body`);".formatted(keyword),
+                "%s targetElement_000 = document.querySelector(`:root > body`);".formatted(keyword),
                 "%s details_000 = document.createElement('details');".formatted(keyword),
                 "details_000.setAttribute(`open`, `true`);",
-                "targetElement_001.appendChild(details_000);");
-        // TODO: Name counter need reset across calls to convert
+                "targetElement_000.appendChild(details_000);");
         assertThat(convert("<p class></p>", new Configuration(variableDeclaration))).containsExactly(
-                "%s targetElement_002 = document.querySelector(`:root > body`);".formatted(keyword),
+                "%s targetElement_000 = document.querySelector(`:root > body`);".formatted(keyword),
                 "%s p_000 = document.createElement('p');".formatted(keyword),
                 "p_000.setAttribute(`class`, ``);",
-                "targetElement_002.appendChild(p_000);");
+                "targetElement_000.appendChild(p_000);");
     }
 
 


### PR DESCRIPTION
# What's Inside

+ [x] Type-based variable naming strategy counters must be scooped to single convert call: this guarantee consistent output/behaviour

# Notice

+ This follows https://github.com/osscameroon/js-generator/pull/166