### PR TITLE
fix: compilation failure due to  4 modules (dependencies of eu.hansolo.tilesfx) not found

### DIFF
--- a/jsgenerator-desktop/pom.xml
+++ b/jsgenerator-desktop/pom.xml
@@ -83,7 +83,7 @@
             <artifactId>bootstrapfx-core</artifactId>
             <version>0.4.0</version>
         </dependency>
-        <!--dependency>
+        <dependency>
             <groupId>eu.hansolo</groupId>
             <artifactId>tilesfx</artifactId>
             <version>17.1.9</version>
@@ -93,7 +93,7 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency-->
+        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION

There was an issue while trying to run `javafx:run`. In fact, dependencies of **eu.hansolo.tilesfx (countries, heatmap, toolbox,  toolboxfx)** were not found by **Maven 3.8.6**. This is why this dependency tilesfx was commented.  One way to solve this problem is  to add these dependencies in the pom while using Maven 3.8.6. We were supposed to use that solution but after starting using **Maven 4** in order to run every module easily, the problem got solved without adding these 4 dependencies.