### PR TITLE
fix: uncommenting-module eu.hansolo.tilesfxtilesfx

### DIFF
--- a/jsgenerator-desktop/pom.xml
+++ b/jsgenerator-desktop/pom.xml
@@ -95,6 +95,65 @@
             </exclusions>
         </dependency>
 
+        <!-- Dependency of eu.hansolo.tilesfx
+        We added it in pom in order to avoid "module not found: eu.hansolo.fx.countries"
+        -->
+
+        <dependency>
+            <groupId>eu.hansolo.fx</groupId>
+            <artifactId>countries</artifactId>
+            <version>17.0.22</version>
+
+        </dependency>
+
+
+        <!-- Dependency of eu.hansolo.tilesfx
+        We added it in pom in order to avoid "module not found: eu.hansolo.fx.heatmap"
+        -->
+
+        <dependency>
+            <groupId>eu.hansolo.fx</groupId>
+            <artifactId>heatmap</artifactId>
+            <version>17.0.9</version>
+
+        </dependency>
+
+
+        <!-- Dependency of eu.hansolo.tilesfx
+        We added it in pom in order to avoid "module not found: eu.hansolo.toolboxfx"
+        -->
+        <dependency>
+            <groupId>eu.hansolo</groupId>
+            <artifactId>toolboxfx</artifactId>
+            <version>17.0.28</version>
+
+        </dependency>
+
+
+        <!-- Dependency of eu.hansolo.tilesfx
+        We added it in pom in order to avoid "module not found: eu.hansolo.toolbox"
+        -->
+
+        <dependency>
+            <groupId>eu.hansolo</groupId>
+            <artifactId>toolbox</artifactId>
+            <version>17.0.22</version>
+
+        </dependency>
+
+        <!-- Dependency of eu.hansolo.tilesfx
+        We added it in pom in order to avoid "module not found: javafx.swing"
+        -->
+
+
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-swing</artifactId>
+            <version>20-ea+4</version>
+        </dependency>
+
+
+
     </dependencies>
 
     <build>

--- a/jsgenerator-desktop/src/main/java/module-info.java
+++ b/jsgenerator-desktop/src/main/java/module-info.java
@@ -11,7 +11,7 @@ module com.osscameroon.jsgenerator.desktop {
     requires net.synedra.validatorfx;
     requires org.kordamp.ikonli.javafx;
     requires org.kordamp.bootstrapfx.core;
-    //requires eu.hansolo.tilesfx;
+    requires eu.hansolo.tilesfx;
 
     opens com.osscameroon.jsgenerator.desktop to javafx.fxml;
     exports com.osscameroon.jsgenerator.desktop;


### PR DESCRIPTION
Previously (https://github.com/osscameroon/js-generator/commit/b6553822815a74ef4b8b5fada38e54ef3c388d14), we thought that moving from Maven 3.8.6 to 4 helps us to not be forced to add the dependencies needed by tilesfx to run the desktop app but it's wrong. It looked like it was the solution because the module tilesfx was commented in module-info.java. Module tilesfx was commented in order to solve the issue later. Now, we are happy that it is finally solved.