### PR TITLE
feat: improve pipelines

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ main ]
   pull_request_target:
-    types: [ opened, edited ]
+    types: [ opened, edited, synchronize, ready_for_review, review_requested, review_request_removed ]
     branches: [ main ]
 
 jobs:


### PR DESCRIPTION
When updating (like new commits) an opened PR, maven.yml pipeline is not executed so we updated the event  pull_request_target with new types: 

**synchronize**: commit(s) pushed to the pull request
**ready_for_review**: pull request is taken out from draft mode
**review_requested**: request a user for review
**review_request_remove**: remove request from user for review

The following links help to understand how to trigger the workflow: 

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target 

https://frontside.com/blog/2020-05-26-github-actions-pull_request/