### PR TITLE
fix. add the getter of boolean querySelectorAdded

### DIFF
--- a/jsgenerator-slim-cli/src/main/java/com/osscameroon/jsgenerator/cli/Command.java
+++ b/jsgenerator-slim-cli/src/main/java/com/osscameroon/jsgenerator/cli/Command.java
@@ -15,6 +15,8 @@ public interface Command extends Callable<Integer> {
 
     String getTargetElementSelector();
 
+    boolean isQuerySelectorAdded();
+
     List<String> getInlineContents();
 
     Converter getConverter();


### PR DESCRIPTION
The interface Command had all getters for every attribute of Configuration but was missing the getter of that boolean