### PR TITLE
Logging Experiment & Comparison with other converters from Html to Js

### DIFF
--- a/jsgenerator-test/jsgenerator-test-core/src/main/java/module-info.java
+++ b/jsgenerator-test/jsgenerator-test-core/src/main/java/module-info.java
@@ -1,2 +1,3 @@
 open module com.osscameroon.jsgenerator.test.core.noop {
+    requires java.logging;
 }

--- a/jsgenerator-test/jsgenerator-test-core/src/main/java/module-info.java
+++ b/jsgenerator-test/jsgenerator-test-core/src/main/java/module-info.java
@@ -1,3 +1,2 @@
 open module com.osscameroon.jsgenerator.test.core.noop {
-    requires java.logging;
 }

--- a/jsgenerator-test/jsgenerator-test-core/src/test/java/com/osscameroon/jsgenerator/test/core/ConverterTest.java
+++ b/jsgenerator-test/jsgenerator-test-core/src/test/java/com/osscameroon/jsgenerator/test/core/ConverterTest.java
@@ -56,7 +56,7 @@ public class ConverterTest {
     * */
     @ParameterizedTest
     @MethodSource("provideVariableDeclarationsAndQuerySelectorAdded")
-    public void trying1(final VariableDeclaration variableDeclaration, final boolean querySelectorAdded) throws IOException {
+    public void comparisonBetweenJsGeneratorAndOtherConverters(final VariableDeclaration variableDeclaration, final boolean querySelectorAdded) throws IOException {
         final var keyword = keyword(variableDeclaration);
         final var converted = convert("""
                         <h1>HTML To JavaScript</h1>

--- a/jsgenerator-test/jsgenerator-test-core/src/test/java/com/osscameroon/jsgenerator/test/core/ConverterTest.java
+++ b/jsgenerator-test/jsgenerator-test-core/src/test/java/com/osscameroon/jsgenerator/test/core/ConverterTest.java
@@ -45,6 +45,15 @@ public class ConverterTest {
         converter = Converter.of();
     }
 
+    /*
+    * The goal is to show how precise is our conversion compared to other websites such as:
+    *
+    * https://www.html-code-generator.com/html/html-code-convert-to-javascript
+    *
+    * https://wtools.io/html-to-javascript-converter
+    *
+    * TODO: Add javadoc with the results coming from these 2 sites
+    * */
     @ParameterizedTest
     @MethodSource("provideVariableDeclarationsAndQuerySelectorAdded")
     public void trying1(final VariableDeclaration variableDeclaration, final boolean querySelectorAdded) throws IOException {

--- a/jsgenerator-test/jsgenerator-test-core/src/test/java/com/osscameroon/jsgenerator/test/core/ConverterTest.java
+++ b/jsgenerator-test/jsgenerator-test-core/src/test/java/com/osscameroon/jsgenerator/test/core/ConverterTest.java
@@ -16,6 +16,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -24,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
 public class ConverterTest {
+    private static final Logger logger = Logger.getLogger(ConverterTest.class.getName());
     private Converter converter;
 
     private static Stream<Arguments> provideVariableDeclarationsAndQuerySelectorAdded() {
@@ -42,6 +45,92 @@ public class ConverterTest {
     public void before() {
         converter = Converter.of();
     }
+
+    @ParameterizedTest
+    @MethodSource("provideVariableDeclarationsAndQuerySelectorAdded")
+    public void trying1(final VariableDeclaration variableDeclaration, final boolean querySelectorAdded) throws IOException {
+        final var keyword = keyword(variableDeclaration);
+        final var converted = convert("""
+                        <h1>HTML To JavaScript</h1>
+                        <ol>
+                            <li>First item</li>
+                            <li>Second item</li>
+                            <li>Third item</li>
+                            <li>Fourth item</li>
+                        </ol>
+                         """,
+                new Configuration(variableDeclaration, querySelectorAdded));
+
+        printConverted(converted);
+
+
+//        let targetElement_000 = document.querySelector(`:root > body`);
+//        let h1_000 = document.createElement('h1');
+//        let text_000 = document.createTextNode(`HTML To JavaScript`);
+//        h1_000.appendChild(text_000);
+//        targetElement_000.appendChild(h1_000);
+//        let text_001 = document.createTextNode(`                                             `);
+//        targetElement_000.appendChild(text_001);
+//        let ol_000 = document.createElement('ol');
+//        let text_002 = document.createTextNode(`                                                 `);
+//        ol_000.appendChild(text_002);
+//        let li_000 = document.createElement('li');
+//        let text_003 = document.createTextNode(`First item`);
+//        li_000.appendChild(text_003);
+//        ol_000.appendChild(li_000);
+//        let text_004 = document.createTextNode(`                                                 `);
+//        ol_000.appendChild(text_004);
+//        let li_001 = document.createElement('li');
+//        let text_005 = document.createTextNode(`Second item`);
+//        li_001.appendChild(text_005);
+//        ol_000.appendChild(li_001);
+//        let text_006 = document.createTextNode(`                                                 `);
+//        ol_000.appendChild(text_006);
+//        let li_002 = document.createElement('li');
+//        let text_007 = document.createTextNode(`Third item`);
+//        li_002.appendChild(text_007);
+//        ol_000.appendChild(li_002);
+//        let text_008 = document.createTextNode(`                                                 `);
+//        ol_000.appendChild(text_008);
+//        let li_003 = document.createElement('li');
+//        let text_009 = document.createTextNode(`Fourth item`);
+//        li_003.appendChild(text_009);
+//        ol_000.appendChild(li_003);
+//        let text_010 = document.createTextNode(`                                             `);
+//        ol_000.appendChild(text_010);
+//        targetElement_000.appendChild(ol_000);
+
+
+        if (querySelectorAdded) {
+
+//            assertThat(converted).containsExactly(
+//                    "%s targetElement_000 = document.querySelector(`:root > body`);".formatted(keyword),
+//                    "%s custom_angulartext_000 = document.createElement('AngularText');".formatted(keyword),
+//                    "%s text_000 = document.createTextNode(`Angular`);".formatted(keyword),
+//                    "custom_angulartext_000.appendChild(text_000);",
+//                    "targetElement_000.appendChild(custom_angulartext_000);",
+//                    "%s custom_web_component_000 = document.createElement('web-component');".formatted(keyword),
+//                    "%s text_001 = document.createTextNode(`Web Component`);".formatted(keyword),
+//                    "custom_web_component_000.appendChild(text_001);",
+//                    "targetElement_000.appendChild(custom_web_component_000);");
+
+        } else {
+
+//            assertThat(converted).containsExactly(
+//                    "%s custom_angulartext_000 = document.createElement('AngularText');".formatted(keyword),
+//                    "%s text_000 = document.createTextNode(`Angular`);".formatted(keyword),
+//                    "custom_angulartext_000.appendChild(text_000);",
+//
+//                    "%s custom_web_component_000 = document.createElement('web-component');".formatted(keyword),
+//                    "%s text_001 = document.createTextNode(`Web Component`);".formatted(keyword),
+//                    "custom_web_component_000.appendChild(text_001);");
+
+
+        }
+
+
+    }
+
 
     @ParameterizedTest
     @MethodSource("provideVariableDeclarationsAndQuerySelectorAdded")
@@ -724,10 +813,16 @@ public class ConverterTest {
 
     private void printConverted(String[] s) {
 
-        System.err.println("\n");
-        System.err.println("-------------------------------------------------------------------");
-        Arrays.asList(s).stream().forEach(System.out::println);
-        System.err.println("-------------------------------------------------------------------");
-        System.err.println("\n");
+
+        String sa = String.join("\n",s);
+
+        String a= """
+                
+                -------------------------------------------------------------------
+                
+                
+                """;
+
+        logger.log(Level.INFO, a+sa+a);
     }
 }

--- a/jsgenerator-test/jsgenerator-test-core/src/test/java/com/osscameroon/jsgenerator/test/core/ConverterTest.java
+++ b/jsgenerator-test/jsgenerator-test-core/src/test/java/com/osscameroon/jsgenerator/test/core/ConverterTest.java
@@ -10,23 +10,22 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Arrays;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.slf4j.LoggerFactory.getLogger;
 
 @ExtendWith(MockitoExtension.class)
 public class ConverterTest {
-    private static final Logger logger = Logger.getLogger(ConverterTest.class.getName());
+    private static final Logger logger = getLogger(ConverterTest.class);
     private Converter converter;
 
     private static Stream<Arguments> provideVariableDeclarationsAndQuerySelectorAdded() {
@@ -814,15 +813,15 @@ public class ConverterTest {
     private void printConverted(String[] s) {
 
 
-        String sa = String.join("\n",s);
+        String convertedString = String.join("\n", s);
 
-        String a= """
-                
+        String space = """
+                                
                 -------------------------------------------------------------------
-                
-                
+                                
+                                
                 """;
 
-        logger.log(Level.INFO, a+sa+a);
+        logger.info(space + convertedString + space);
     }
 }

--- a/jsgenerator-test/jsgenerator-test-core/src/test/java/com/osscameroon/jsgenerator/test/core/ConverterTest.java
+++ b/jsgenerator-test/jsgenerator-test-core/src/test/java/com/osscameroon/jsgenerator/test/core/ConverterTest.java
@@ -23,6 +23,15 @@ import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.slf4j.LoggerFactory.getLogger;
 
+
+/*
+*
+* TODO: Every test should be also validated on JSFiddle (https://jsfiddle.net/) and CodePen (https://codepen.io/).
+*  The goal is to see if the js output matches the html code by pasting each code then see how they are rendered.
+*  "document.querySelector(`:root > body`);" must be added to see the resuts.
+*  To do so, just copy and paste the result from the method "printConverted(String[])".
+*
+* */
 @ExtendWith(MockitoExtension.class)
 public class ConverterTest {
     private static final Logger logger = getLogger(ConverterTest.class);
@@ -45,20 +54,107 @@ public class ConverterTest {
         converter = Converter.of();
     }
 
-    /*
-    * The goal is to show how precise is our conversion compared to other websites such as:
-    *
-    * https://www.html-code-generator.com/html/html-code-convert-to-javascript
-    *
-    * https://wtools.io/html-to-javascript-converter
-    *
-    * TODO: Add javadoc with the results coming from these 2 sites
-    * */
+    /**
+     * The goal is to show how precise is our conversion compared to other websites such as
+     * <a href="https://www.html-code-generator.com/html/html-code-convert-to-javascript">HTML Code Generator</a>
+     * and <a href="https://wtools.io/html-to-javascript-converter">WTOOLS</a>.
+     *
+     *
+     <br>
+     <br>
+     *
+     *
+     * Result of HTML conversion to JS code from
+     * <a href="https://www.html-code-generator.com/html/html-code-convert-to-javascript">HTML Code Generator</a>:
+     *
+     *
+     *
+     *
+     * <pre>
+     *     {@code
+     *
+            let code = "";
+            code += "<h1>HTML To JavaScript</h1>\n";
+            code += "<ol>\n";
+            code += "\t<li>First item</li>\n";
+            code += "\t<li>Second item</li>\n";
+            code += "\t<li>Third item</li>\n";
+            code += "\t<li>Fourth item</li>\n";
+            code += "</ol>\n";
+     *
+     *
+     *     }
+     * </pre>
+
+     *
+     *
+     *
+     *3 possible results of HTML conversion to JS code from  <a href="https://wtools.io/html-to-javascript-converter">WTOOLS</a>:
+     *
+     *
+     * <pre>
+     *     {@code
+     *
+     *     document.write('<h1>HTML To JavaScript</h1>');
+     *     document.write('<ol>');
+     *     document.write('    <li>First item</li>');
+     *     document.write('    <li>Second item</li>');
+     *     document.write('    <li>Third item</li>');
+     *     document.write('    <li>Fourth item</li>');
+     *     document.write('</ol>');
+     *
+     *
+     *     }
+     * </pre>
+     *
+     *-----------------------------------------------------
+     *
+     * <pre>
+     *     {@code
+     *
+     *     document.writeln('<h1>HTML To JavaScript</h1>');
+     *     document.writeln('<ol>');
+     *     document.writeln('    <li>First item</li>');
+     *     document.writeln('    <li>Second item</li>');
+     *     document.writeln('    <li>Third item</li>');
+     *     document.writeln('    <li>Fourth item</li>');
+     *     document.writeln('</ol>');
+     *
+     *
+     *     }
+     * </pre>
+
+
+     -----------------------------------------------------
+
+     * <pre>
+     *     {@code
+     *
+            var variable = '' +
+            '<h1>HTML To JavaScript</h1>' +
+            '<ol>' +
+            '    <li>First item</li>' +
+            '    <li>Second item</li>' +
+            '    <li>Third item</li>' +
+            '    <li>Fourth item</li>' +
+            '</ol>' +
+            '';
+     *
+     *
+     *     }
+     * </pre>
+     *
+     *
+     * Our 3 possible results use let,var and const as variable declarations, we also generate js variable for each element.
+     *
+     *
+     * */
     @ParameterizedTest
     @MethodSource("provideVariableDeclarationsAndQuerySelectorAdded")
     public void comparisonBetweenJsGeneratorAndOtherConverters(final VariableDeclaration variableDeclaration, final boolean querySelectorAdded) throws IOException {
         final var keyword = keyword(variableDeclaration);
-        final var converted = convert("""
+        final var converted = convert(
+                """
                         <h1>HTML To JavaScript</h1>
                         <ol>
                             <li>First item</li>
@@ -72,73 +168,84 @@ public class ConverterTest {
         printConverted(converted);
 
 
-//        let targetElement_000 = document.querySelector(`:root > body`);
-//        let h1_000 = document.createElement('h1');
-//        let text_000 = document.createTextNode(`HTML To JavaScript`);
-//        h1_000.appendChild(text_000);
-//        targetElement_000.appendChild(h1_000);
-//        let text_001 = document.createTextNode(`                                             `);
-//        targetElement_000.appendChild(text_001);
-//        let ol_000 = document.createElement('ol');
-//        let text_002 = document.createTextNode(`                                                 `);
-//        ol_000.appendChild(text_002);
-//        let li_000 = document.createElement('li');
-//        let text_003 = document.createTextNode(`First item`);
-//        li_000.appendChild(text_003);
-//        ol_000.appendChild(li_000);
-//        let text_004 = document.createTextNode(`                                                 `);
-//        ol_000.appendChild(text_004);
-//        let li_001 = document.createElement('li');
-//        let text_005 = document.createTextNode(`Second item`);
-//        li_001.appendChild(text_005);
-//        ol_000.appendChild(li_001);
-//        let text_006 = document.createTextNode(`                                                 `);
-//        ol_000.appendChild(text_006);
-//        let li_002 = document.createElement('li');
-//        let text_007 = document.createTextNode(`Third item`);
-//        li_002.appendChild(text_007);
-//        ol_000.appendChild(li_002);
-//        let text_008 = document.createTextNode(`                                                 `);
-//        ol_000.appendChild(text_008);
-//        let li_003 = document.createElement('li');
-//        let text_009 = document.createTextNode(`Fourth item`);
-//        li_003.appendChild(text_009);
-//        ol_000.appendChild(li_003);
-//        let text_010 = document.createTextNode(`                                             `);
-//        ol_000.appendChild(text_010);
-//        targetElement_000.appendChild(ol_000);
-
-
         if (querySelectorAdded) {
 
-//            assertThat(converted).containsExactly(
-//                    "%s targetElement_000 = document.querySelector(`:root > body`);".formatted(keyword),
-//                    "%s custom_angulartext_000 = document.createElement('AngularText');".formatted(keyword),
-//                    "%s text_000 = document.createTextNode(`Angular`);".formatted(keyword),
-//                    "custom_angulartext_000.appendChild(text_000);",
-//                    "targetElement_000.appendChild(custom_angulartext_000);",
-//                    "%s custom_web_component_000 = document.createElement('web-component');".formatted(keyword),
-//                    "%s text_001 = document.createTextNode(`Web Component`);".formatted(keyword),
-//                    "custom_web_component_000.appendChild(text_001);",
-//                    "targetElement_000.appendChild(custom_web_component_000);");
+
+            assertThat(converted).containsExactly( "%s targetElement_000 = document.querySelector(`:root > body`);".formatted(keyword),
+                    "%s h1_000 = document.createElement('h1');".formatted(keyword),
+                    "%s text_000 = document.createTextNode(`HTML To JavaScript`);".formatted(keyword),
+                    "h1_000.appendChild(text_000);",
+                    "targetElement_000.appendChild(h1_000);",
+                    "%s ol_000 = document.createElement('ol');".formatted(keyword),
+                    "%s text_001 = document.createTextNode(`    `);".formatted(keyword),
+                    "ol_000.appendChild(text_001);",
+                    "%s li_000 = document.createElement('li');".formatted(keyword),
+                    "%s text_002 = document.createTextNode(`First item`);".formatted(keyword),
+                    "li_000.appendChild(text_002);",
+                    "ol_000.appendChild(li_000);",
+                    "%s text_003 = document.createTextNode(`    `);".formatted(keyword),
+                    "ol_000.appendChild(text_003);",
+                    "%s li_001 = document.createElement('li');".formatted(keyword),
+                    "%s text_004 = document.createTextNode(`Second item`);".formatted(keyword),
+                    "li_001.appendChild(text_004);",
+                    "ol_000.appendChild(li_001);",
+                    "%s text_005 = document.createTextNode(`    `);".formatted(keyword),
+                    "ol_000.appendChild(text_005);",
+                    "%s li_002 = document.createElement('li');".formatted(keyword),
+                    "%s text_006 = document.createTextNode(`Third item`);".formatted(keyword),
+                    "li_002.appendChild(text_006);",
+                    "ol_000.appendChild(li_002);",
+                    "%s text_007 = document.createTextNode(`    `);".formatted(keyword),
+                    "ol_000.appendChild(text_007);",
+                    "%s li_003 = document.createElement('li');".formatted(keyword),
+                    "%s text_008 = document.createTextNode(`Fourth item`);".formatted(keyword),
+                    "li_003.appendChild(text_008);",
+                    "ol_000.appendChild(li_003);",
+                    "targetElement_000.appendChild(ol_000);"
+
+            );
+
 
         } else {
 
-//            assertThat(converted).containsExactly(
-//                    "%s custom_angulartext_000 = document.createElement('AngularText');".formatted(keyword),
-//                    "%s text_000 = document.createTextNode(`Angular`);".formatted(keyword),
-//                    "custom_angulartext_000.appendChild(text_000);",
-//
-//                    "%s custom_web_component_000 = document.createElement('web-component');".formatted(keyword),
-//                    "%s text_001 = document.createTextNode(`Web Component`);".formatted(keyword),
-//                    "custom_web_component_000.appendChild(text_001);");
+            assertThat(converted).containsExactly(
+
+                    "%s h1_000 = document.createElement('h1');".formatted(keyword),
+                    "%s text_000 = document.createTextNode(`HTML To JavaScript`);".formatted(keyword),
+                    "h1_000.appendChild(text_000);",
+                    "%s ol_000 = document.createElement('ol');".formatted(keyword),
+                    "%s text_001 = document.createTextNode(`    `);".formatted(keyword),
+                    "ol_000.appendChild(text_001);",
+                    "%s li_000 = document.createElement('li');".formatted(keyword),
+                    "%s text_002 = document.createTextNode(`First item`);".formatted(keyword),
+                    "li_000.appendChild(text_002);",
+                    "ol_000.appendChild(li_000);",
+                    "%s text_003 = document.createTextNode(`    `);".formatted(keyword),
+                    "ol_000.appendChild(text_003);",
+                    "%s li_001 = document.createElement('li');".formatted(keyword),
+                    "%s text_004 = document.createTextNode(`Second item`);".formatted(keyword),
+                    "li_001.appendChild(text_004);",
+                    "ol_000.appendChild(li_001);",
+                    "%s text_005 = document.createTextNode(`    `);".formatted(keyword),
+                    "ol_000.appendChild(text_005);",
+                    "%s li_002 = document.createElement('li');".formatted(keyword),
+                    "%s text_006 = document.createTextNode(`Third item`);".formatted(keyword),
+                    "li_002.appendChild(text_006);",
+                    "ol_000.appendChild(li_002);",
+                    "%s text_007 = document.createTextNode(`    `);".formatted(keyword),
+                    "ol_000.appendChild(text_007);",
+                    "%s li_003 = document.createElement('li');".formatted(keyword),
+                    "%s text_008 = document.createTextNode(`Fourth item`);".formatted(keyword),
+                    "li_003.appendChild(text_008);",
+                    "ol_000.appendChild(li_003);"
+
+            );
 
 
         }
 
 
     }
-
 
     @ParameterizedTest
     @MethodSource("provideVariableDeclarationsAndQuerySelectorAdded")

--- a/jsgenerator-test/jsgenerator-test-core/src/test/java/com/osscameroon/jsgenerator/test/core/ConverterTest.java
+++ b/jsgenerator-test/jsgenerator-test-core/src/test/java/com/osscameroon/jsgenerator/test/core/ConverterTest.java
@@ -145,7 +145,7 @@ public class ConverterTest {
      * </pre>
      *
      *
-     * Our 3 possible results use let,var and const as variable declarations, we also generate js variable for each element.
+     * Our results use let,var and const as variable declarations, we also generate js variable for each element.
      *
      *
      * */

--- a/jsgenerator-test/jsgenerator-test-core/src/test/java/module-info.java
+++ b/jsgenerator-test/jsgenerator-test-core/src/test/java/module-info.java
@@ -11,5 +11,5 @@ module com.osscameroon.jsgenerator.test.core {
     requires org.mockito.junit.jupiter;
     requires org.junit.jupiter.params;
 
-    requires java.logging;
+    requires org.slf4j;
 }

--- a/jsgenerator-test/jsgenerator-test-core/src/test/java/module-info.java
+++ b/jsgenerator-test/jsgenerator-test-core/src/test/java/module-info.java
@@ -10,4 +10,6 @@ module com.osscameroon.jsgenerator.test.core {
     requires org.mockito;
     requires org.mockito.junit.jupiter;
     requires org.junit.jupiter.params;
+
+    requires java.logging;
 }


### PR DESCRIPTION
+ [x] Solve module issue java.util.logging
+ [x] Comparison between JsGenerator and other converters


I was trying to use java.util.logging but it did not work. It worked, I mean I  got some logs but there were some issues ( https://github.com/osscameroon/js-generator/commit/ee0d7b2dde9262ed94ac5b7e316655d9307e6443 ) related to logging on java modules. SL4J looks like a solution for that purpose.

> module issue java.util.logging
> 
> https://www.google.com/search?q=module+issue+java.util%2Clogging&rlz=1C1FCXM_pt-PTPT1032PT1032&oq=module+issue+java.util%2Clogging&aqs=chrome..69i57j33i22i29i30.17735j1j7&sourceid=chrome&ie=UTF-8
> 
> https://stackoverflow.com/questions/70532618/package-java-util-logging-is-not-visible-adding-requires-java-logging-in-mod
> 
> https://github.com/classgraph/classgraph/issues/309
> 
> https://www.eclipse.org/forums/index.php/t/1103515/