### PR TITLE
feat: Upgrade pom.xml to use maven 4.1.0 model

### DIFF
--- a/jsgenerator-api/pom.xml
+++ b/jsgenerator-api/pom.xml
@@ -7,7 +7,7 @@
         <groupId>com.osscameroon</groupId>
         <version>${revision}</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.1.0</modelVersion>
 
     <artifactId>jsgenerator-api</artifactId>
 

--- a/jsgenerator-api/pom.xml
+++ b/jsgenerator-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd">
     <parent>
         <artifactId>jsgenerator</artifactId>
         <groupId>com.osscameroon</groupId>

--- a/jsgenerator-cli/pom.xml
+++ b/jsgenerator-cli/pom.xml
@@ -7,7 +7,7 @@
         <groupId>com.osscameroon</groupId>
         <version>${revision}</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.1.0</modelVersion>
 
     <artifactId>jsgenerator-cli</artifactId>
 

--- a/jsgenerator-cli/pom.xml
+++ b/jsgenerator-cli/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd">
     <parent>
         <artifactId>jsgenerator</artifactId>
         <groupId>com.osscameroon</groupId>

--- a/jsgenerator-core/pom.xml
+++ b/jsgenerator-core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd">
     <parent>
         <artifactId>jsgenerator</artifactId>
         <groupId>com.osscameroon</groupId>

--- a/jsgenerator-core/pom.xml
+++ b/jsgenerator-core/pom.xml
@@ -8,7 +8,7 @@
         <version>${revision}</version>
     </parent>
     <packaging>jar</packaging>
-    <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.1.0</modelVersion>
 
     <artifactId>jsgenerator-core</artifactId>
 

--- a/jsgenerator-desktop/pom.xml
+++ b/jsgenerator-desktop/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
 
     <parent>
         <artifactId>jsgenerator</artifactId>

--- a/jsgenerator-desktop/pom.xml
+++ b/jsgenerator-desktop/pom.xml
@@ -9,7 +9,7 @@
         <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.1.0</modelVersion>
     <artifactId>jsgenerator-desktop</artifactId>
     <name>jsgenerator-desktop</name>
 

--- a/jsgenerator-slim-api/pom.xml
+++ b/jsgenerator-slim-api/pom.xml
@@ -7,7 +7,7 @@
         <groupId>com.osscameroon</groupId>
         <version>${revision}</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.1.0</modelVersion>
 
     <artifactId>jsgenerator-slim-api</artifactId>
 

--- a/jsgenerator-slim-api/pom.xml
+++ b/jsgenerator-slim-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd">
     <parent>
         <artifactId>jsgenerator</artifactId>
         <groupId>com.osscameroon</groupId>

--- a/jsgenerator-slim-cli/pom.xml
+++ b/jsgenerator-slim-cli/pom.xml
@@ -7,7 +7,7 @@
         <groupId>com.osscameroon</groupId>
         <version>${revision}</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.1.0</modelVersion>
 
     <artifactId>jsgenerator-slim-cli</artifactId>
 

--- a/jsgenerator-slim-cli/pom.xml
+++ b/jsgenerator-slim-cli/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd">
     <parent>
         <artifactId>jsgenerator</artifactId>
         <groupId>com.osscameroon</groupId>

--- a/jsgenerator-test/jsgenerator-test-api/pom.xml
+++ b/jsgenerator-test/jsgenerator-test-api/pom.xml
@@ -7,7 +7,7 @@
         <groupId>com.osscameroon</groupId>
         <version>${revision}</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.1.0</modelVersion>
 
     <artifactId>jsgenerator-test-api</artifactId>
 

--- a/jsgenerator-test/jsgenerator-test-api/pom.xml
+++ b/jsgenerator-test/jsgenerator-test-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd">
     <parent>
         <artifactId>jsgenerator-test</artifactId>
         <groupId>com.osscameroon</groupId>

--- a/jsgenerator-test/jsgenerator-test-core/pom.xml
+++ b/jsgenerator-test/jsgenerator-test-core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd">
     <parent>
         <artifactId>jsgenerator-test</artifactId>
         <groupId>com.osscameroon</groupId>

--- a/jsgenerator-test/jsgenerator-test-core/pom.xml
+++ b/jsgenerator-test/jsgenerator-test-core/pom.xml
@@ -7,7 +7,7 @@
         <groupId>com.osscameroon</groupId>
         <version>${revision}</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.1.0</modelVersion>
 
     <artifactId>jsgenerator-test-core</artifactId>
 

--- a/jsgenerator-test/jsgenerator-test-desktop/pom.xml
+++ b/jsgenerator-test/jsgenerator-test-desktop/pom.xml
@@ -7,7 +7,7 @@
         <groupId>com.osscameroon</groupId>
         <version>${revision}</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.1.0</modelVersion>
 
     <artifactId>jsgenerator-test-desktop</artifactId>
 

--- a/jsgenerator-test/jsgenerator-test-desktop/pom.xml
+++ b/jsgenerator-test/jsgenerator-test-desktop/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd">
     <parent>
         <artifactId>jsgenerator-test</artifactId>
         <groupId>com.osscameroon</groupId>

--- a/jsgenerator-test/pom.xml
+++ b/jsgenerator-test/pom.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd">
     <parent>
         <artifactId>jsgenerator</artifactId>
         <groupId>com.osscameroon</groupId>
         <version>${revision}</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.1.0</modelVersion>
 
     <artifactId>jsgenerator-test</artifactId>
     <packaging>pom</packaging>
-    <modules>
-        <module>jsgenerator-test-core</module>
-        <module>jsgenerator-test-api</module>
-        <module>jsgenerator-test-desktop</module>
-    </modules>
+    <subprojects>
+        <subproject>jsgenerator-test-core</subproject>
+        <subproject>jsgenerator-test-api</subproject>
+        <subproject>jsgenerator-test-desktop</subproject>
+    </subprojects>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,19 +1,19 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd" root="true">
+    <modelVersion>4.1.0</modelVersion>
     <groupId>com.osscameroon</groupId>
     <artifactId>jsgenerator</artifactId>
     <packaging>pom</packaging>
     <version>${revision}</version>
-    <modules>
-        <module>jsgenerator-core</module>
-        <module>jsgenerator-test</module>
-        <module>jsgenerator-slim-cli</module>
-        <module>jsgenerator-slim-api</module>
-        <module>jsgenerator-api</module>
-        <module>jsgenerator-cli</module>
-        <module>jsgenerator-desktop</module>
-    </modules>
+    <subprojects>
+        <subproject>jsgenerator-core</subproject>
+        <subproject>jsgenerator-test</subproject>
+        <subproject>jsgenerator-slim-cli</subproject>
+        <subproject>jsgenerator-slim-api</subproject>
+        <subproject>jsgenerator-api</subproject>
+        <subproject>jsgenerator-cli</subproject>
+        <subproject>jsgenerator-desktop</subproject>
+    </subprojects>
 
     <parent>
         <artifactId>spring-boot-starter-parent</artifactId>


### PR DESCRIPTION
Fixes #275

Update the `pom.xml` files in the project to use `modelVersion` 4.1.0

The changes include the following modifications:

- **XML Schema**: Updated the `<project>` tag's `xmlns` and `xsi:schemaLocation` attributes to reference the new 4.1.0 schema.
- **root**: Added the `root="true"` in the root pom.xml.
- **Model Version**: Changed the `<modelVersion>` from 4.0.0 to 4.1.0.
- **subprojects and subproject**: Replaced the now deprecated `<modules>` and `<module>` tag with the new `<subprojects>` and `<subproject>` tags.